### PR TITLE
feat: index GCS metadata in Cloud Spanner

### DIFF
--- a/ci/kokoro/check_style.sh
+++ b/ci/kokoro/check_style.sh
@@ -61,7 +61,7 @@ echo "================================================================"
 echo "Building docker image with the following flags $(date)."
 printf '%s\n' "${build_flags[@]}"
 
-if docker build "${build_flags[@]}" .; then
+if docker build "${build_flags[@]}" ci; then
    update_cache="true"
 fi
 

--- a/gcs-indexer/.clang-format
+++ b/gcs-indexer/.clang-format
@@ -23,11 +23,3 @@ IncludeCategories:
   Priority: 4000
 - Regex: '^<[^/]*>'
   Priority: 5000
-
-# Format raw string literals with a `pb` or `proto` tag as proto.
-RawStringFormats:
-- Language: TextProto
-  Delimiters:
-  - 'pb'
-  - 'proto'
-  BasedOnStyle: Google

--- a/gcs-indexer/.clang-format
+++ b/gcs-indexer/.clang-format
@@ -1,0 +1,33 @@
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+IncludeBlocks: Merge
+IncludeCategories:
+- Regex: '^\"google/cloud/spanner'
+  Priority: 500
+- Regex: '^\"google/cloud/'
+  Priority: 1500
+- Regex: '^\"'
+  Priority: 1000
+- Regex: '^<grpc/'
+  Priority: 2000
+- Regex: '^<google/*'
+  Priority: 3000
+- Regex: '^<.*/.*'
+  Priority: 4000
+- Regex: '^<[^/]*>'
+  Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google

--- a/gcs-indexer/.clang-tidy
+++ b/gcs-indexer/.clang-tidy
@@ -1,0 +1,45 @@
+---
+# Configure clang-tidy for this project.
+
+# Disabled:
+#  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
+#   clang-tidy fails to match it against the initial value.
+Checks: >
+  -*,
+  bugprone-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -google-readability-namespace-comments,
+  -google-runtime-references,
+  -misc-non-private-member-variables-in-classes,
+  -readability-named-parameter,
+  -readability-braces-around-statements,
+  -readability-magic-numbers
+
+HeaderFilterRegex: ".*"
+
+# Turn all the warnings from the checks above into errors.
+WarningsAsErrors: "*"
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: lower_case }
+  - { key: readability-identifier-naming.StructCase,             value: lower_case }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberSuffix,      value: _          }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
+  - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantPrefix,     value: k          }
+  - { key: readability-identifier-naming.ConstexprVariableCase,  value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: lower_case }
+  - { key: readability-identifier-naming.MemberConstantCase,     value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase,     value: lower_case }

--- a/gcs-indexer/.cmake-format.py
+++ b/gcs-indexer/.cmake-format.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tab_size = 4
+separate_ctrl_name_with_space = True
+
+additional_commands = {
+    "externalproject_add": {
+        "flags": [
+        ],
+        "kwargs": {
+            "BUILD_COMMAND": "+",
+            "BUILD_BYPRODUCTS": "+",
+            "CMAKE_ARGS": "+",
+            "COMMAND": "+",
+            "CONFIGURE_COMMAND": "+",
+            "DEPENDS": "+",
+            "DOWNLOAD_COMMAND": "+",
+            "EXCLUDE_FROM_ALL": 1,
+            "INSTALL_COMMAND": "+",
+            "INSTALL_DIR": 1,
+            "TEST_COMMAND": "+",
+            "LOG_BUILD": 1,
+            "LOG_CONFIGURE": 1,
+            "LOG_DOWNLOAD": 1,
+            "LOG_INSTALL": 1,
+            "PREFIX": 1,
+            "URL": 1,
+            "URL_HASH": 1,
+        }
+    }
+}

--- a/gcs-indexer/.dockerignore
+++ b/gcs-indexer/.dockerignore
@@ -1,0 +1,8 @@
+.build/
+cmake-build-debug/
+cmake-build-release/
+doc/html/
+.git/
+.idea/
+README.md
+cmake-out

--- a/gcs-indexer/.dockerignore
+++ b/gcs-indexer/.dockerignore
@@ -5,4 +5,5 @@ doc/html/
 .git/
 .idea/
 README.md
-cmake-out
+cmake-out/
+.build/

--- a/gcs-indexer/.gitignore
+++ b/gcs-indexer/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+.vscode/
+cmake-build-debug/
+.build
+cmake-out/

--- a/gcs-indexer/CMakeLists.txt
+++ b/gcs-indexer/CMakeLists.txt
@@ -1,0 +1,112 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.10)
+
+# Define the project name and where to report bugs.
+set(PACKAGE_BUGREPORT "https://github.com/googleapis/cpp-gcs-indexer/issues")
+project(Docker-Run-C++ CXX C)
+
+# Configure the Compiler options, we will be using C++17 features.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(spanner_client REQUIRED)
+find_package(storage_client REQUIRED)
+find_package(CURL REQUIRED)
+find_package(Boost 1.66 REQUIRED COMPONENTS program_options)
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+set(EXTRA_LIBRARY "" CACHE FILEPATH "Additional libraries.
+        Several CMake modules (but not CONFIGs!) do not link the dependencies
+        when using static libraries. This flag can be used to add additional
+        from the command line (or a Dockerfile).")
+mark_as_advanced(EXTRA_LIBRARY)
+
+# When using static libraries the FindgRPC.cmake module does not define the
+# correct dependencies (OpenSSL::Crypto, c-cares, etc) for gRPC::grpc.
+# Explicitly listing these dependencies avoids the undefined symbols problems.
+add_executable(pubsub_handler pubsub_handler.cc gcs_indexer_constants.h)
+target_link_libraries(pubsub_handler
+        PRIVATE spanner_client
+        Boost::headers
+        Boost::program_options
+        googleapis-c++::spanner_protos
+        gRPC::grpc++
+        gRPC::grpc
+        ${EXTRA_LIBRARY}
+        OpenSSL::Crypto
+        OpenSSL::SSL
+        ZLIB::ZLIB)
+
+add_executable(create_database create_database.cc)
+target_link_libraries(create_database
+        PRIVATE spanner_client
+        Boost::headers
+        Boost::program_options
+        googleapis-c++::spanner_protos
+        gRPC::grpc++
+        gRPC::grpc
+        ${EXTRA_LIBRARY}
+        OpenSSL::Crypto
+        OpenSSL::SSL
+        ZLIB::ZLIB)
+        
+add_executable(refresh_index_for_bucket refresh_index_for_bucket.cc gcs_indexer_constants.h)
+target_link_libraries(refresh_index_for_bucket
+        PRIVATE spanner_client
+        storage_client
+        Boost::headers
+        Boost::program_options
+        googleapis-c++::spanner_protos
+        gRPC::grpc++
+        gRPC::grpc
+        CURL::libcurl
+        ${EXTRA_LIBRARY}
+        OpenSSL::Crypto
+        OpenSSL::SSL
+        ZLIB::ZLIB)
+
+add_executable(generate_randomly_named_objects generate_randomly_named_objects.cc)
+target_link_libraries(generate_randomly_named_objects
+        PRIVATE storage_client
+        Boost::headers
+        Boost::program_options
+        CURL::libcurl
+        ${EXTRA_LIBRARY}
+        OpenSSL::Crypto
+        OpenSSL::SSL
+        ZLIB::ZLIB)
+
+add_executable(delete_index_for_bucket delete_index_for_bucket.cc)
+target_link_libraries(delete_index_for_bucket
+        PRIVATE spanner_client
+        Boost::headers
+        Boost::program_options
+        googleapis-c++::spanner_protos
+        gRPC::grpc++
+        gRPC::grpc
+        ${EXTRA_LIBRARY}
+        OpenSSL::Crypto
+        OpenSSL::SSL
+        ZLIB::ZLIB)
+
+include(GNUInstallDirs)
+install(
+        TARGETS create_database pubsub_handler
+         refresh_index_for_bucket
+         delete_index_for_bucket
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/gcs-indexer/CMakeLists.txt
+++ b/gcs-indexer/CMakeLists.txt
@@ -17,7 +17,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Define the project name and where to report bugs.
-set(PACKAGE_BUGREPORT "https://github.com/googleapis/cpp-gcs-indexer/issues")
+set(PACKAGE_BUGREPORT "https://github.com/GoogleCloudPlatform/cpp-samples/issues")
 project(Docker-Run-C++ CXX C)
 
 # Configure the Compiler options, we will be using C++17 features.

--- a/gcs-indexer/Dockerfile
+++ b/gcs-indexer/Dockerfile
@@ -1,0 +1,142 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=edge
+FROM alpine:${DISTRO_VERSION} AS base
+
+FROM base AS devtools
+
+# Install the typical development tools and some additions:
+#   - ninja-build is a backend for CMake that often compiles faster than
+#     CMake with GNU Make.
+#   - Install the boost libraries.
+RUN apk update && \
+    apk add \
+        boost-dev \
+        boost-static \
+        build-base \
+        cmake \
+        curl \
+        curl-dev \
+        curl-static \
+        git \
+        gcc \
+        g++ \
+        grpc \
+        grpc-dev \
+        grpc-cli \
+        libc-dev \
+        nghttp2-static \
+        ninja \
+        protobuf \
+        protobuf-dev \
+        openssl-dev \
+        openssl-libs-static \
+        tar \
+        zlib-static
+
+WORKDIR /var/tmp/build
+RUN curl -s -L -o 1.1.0.tar.gz https://github.com/google/crc32c/archive/1.1.0.tar.gz
+RUN tar -zxf 1.1.0.tar.gz
+WORKDIR /var/tmp/build/crc32c-1.1.0
+RUN cmake -S. -B.build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCRC32C_BUILD_TESTS=OFF \
+    -DCRC32C_BUILD_BENCHMARKS=OFF \
+    -DCRC32C_USE_GLOG=OFF
+RUN cmake --build .build --target install
+
+WORKDIR /var/tmp/build
+RUN curl -s -L -o v0.2.1.tar.gz https://github.com/googleapis/cpp-cmakefiles/archive/v0.2.1.tar.gz
+RUN tar -zxf v0.2.1.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.2.1
+RUN cmake -S. -B.build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release
+RUN cmake --build .build --target install
+
+WORKDIR /var/tmp/build
+RUN curl -s -L -o v0.17.0.tar.gz \
+    https://github.com/googleapis/google-cloud-cpp-common/archive/v0.17.0.tar.gz
+RUN tar -zxf v0.17.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.17.0
+RUN cmake -S. -B.build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF
+RUN cmake --build .build --target install
+
+WORKDIR /var/tmp/build
+RUN curl -s -L -o v0.17.0.tar.gz \
+    https://github.com/googleapis/google-cloud-cpp/archive/v0.17.0.tar.gz
+RUN tar -zxf v0.17.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-0.17.0
+RUN cmake -S. -B.build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF
+RUN cmake --build .build --target install
+
+WORKDIR /var/tmp/build
+RUN curl -s -L -o v0.5.0.tar.gz \
+    https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.5.0.tar.gz
+RUN tar -zxf v0.5.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-spanner-0.5.0
+RUN cmake -S. -B.build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF
+RUN cmake --build .build --target install
+
+RUN apk update && \
+    apk add \
+        c-ares-static
+
+FROM devtools AS build
+COPY . /v/source
+WORKDIR /v/source
+RUN cmake -S/v/source -B/v/binary -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBoost_USE_STATIC_LIBS=ON \
+    -D_gRPC_USE_STATIC_LIBS=ON \
+    -DProtobuf_USE_STATIC_LIBS=ON \
+    -DOPENSSL_USE_STATIC_LIBS=ON \
+    -DOPENSSL_CRYPTO_LIBRARY=/usr/lib/libcrypto.a \
+    -DOPENSSL_SSL_LIBRARY=/usr/lib/libssl.a \
+    -DZLIB_LIBRARY=/lib/libz.a \
+    -DEXTRA_LIBRARY="/usr/lib/libnghttp2.a;/usr/lib/libcares.a" \
+    -DCMAKE_EXE_LINKER_FLAGS="-static"
+
+RUN cmake --build /v/binary
+RUN strip /v/binary/pubsub_handler
+
+FROM base AS with-certs
+RUN apk update && \
+    apk add ca-certificates && \
+    rm -rf /var/cache/apk/*
+RUN update-ca-certificates
+
+FROM with-certs AS pubsub-handler
+WORKDIR /r
+COPY --from=build /v/binary/pubsub_handler /r
+
+CMD "/r/pubsub_handler" \
+    "--project=${SPANNER_PROJECT}" \
+    "--instance=${SPANNER_INSTANCE}" \
+    "--database=${SPANNER_DATABASE}"
+
+FROM with-certs AS tools
+WORKDIR /r
+COPY --from=build /v/binary/create_database /r
+COPY --from=build /v/binary/delete_index_for_bucket /r
+COPY --from=build /v/binary/generate_randomly_named_objects /r
+COPY --from=build /v/binary/refresh_index_for_bucket /r
+
+CMD "/bin/false"

--- a/gcs-indexer/README.md
+++ b/gcs-indexer/README.md
@@ -1,0 +1,49 @@
+# Cloud Run for C++
+
+This repository contains an example showing how to deploy C++ applications in
+Google Cloud Run.
+
+## Prerequisites
+
+Install the command-line tools, for example:
+
+```bash
+gcloud components install beta
+gcloud components install kubectl
+gcloud components install docker-credential-gcr
+gcloud auth configure-docker
+```
+
+## Bootstrap the Indexer
+
+Pick the project to run the service and the spanner instance.
+
+```bash
+export GOOGLE_CLOUD_PROJECT=...
+```
+
+Run the program to bootstrap the indexer, this will create the Cloud Spanner
+instance and databases to store the data, the Cloud Run deployments to run the
+indexer, two service accounts to run the Cloud Run deployments, and a Cloud
+Pub/Sub topic to receive GCS metadata updates. It will also setup the IAM
+permissions so Cloud Pub/Sub can push these updates to Cloud Run.
+
+```bash
+./bootstrap-gcs-indexer.sh
+```
+
+## Index an existing Bucket
+
+Then connect the program to one of the buckets in this project. This will
+configure the bucket to publish any metadata updates to the topic created above,
+and start a program to index the existing metadata in the bucket.
+
+```bash
+./refresh-index.sh my-bucket-name
+```
+
+For larger buckets, if they are well partitioned using prefixes, consider using:
+
+```bash
+./refresh-index.sh my-bucket-name/prefix1 my-bucket-name/prefix2 ... my-bucket-name/prefixN
+```

--- a/gcs-indexer/bootstrap-gcs-indexer.sh
+++ b/gcs-indexer/bootstrap-gcs-indexer.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
+  echo "You must set GOOGLE_CLOUD_PROJECT to the project id hosting the GCS" \
+      "metadata indexer"
+  exit 1
+fi
+
+if !type gcloud >/dev/null 2>&1; then
+  echo "gcloud command not found."
+  echo "This script uses gcloud extensively, please install it and add it to your PATH"
+  echo "  https://cloud.google.com/sdk/install"
+  exit 1
+fi
+
+if !type kubectl >/dev/null 2>&1; then
+  echo "kubectl command not found. Trying to install via gcloud"
+  if gcloud components install kubectl; then
+    echo "Success"
+  else
+    echo "kubectl not found and could not be installed."
+    echo "Please install it manually and add it to your PATH"
+    exit 1
+  fi
+fi
+
+GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-}"
+readonly GOOGLE_CLOUD_PROJECT
+GOOGLE_CLOUD_REGION="${REGION:-us-central1}"
+readonly GOOGLE_CLOUD_REGION
+GOOGLE_CLOUD_SPANNER_INSTANCE="${GOOGLE_CLOUD_SPANNER_INSTANCE:-gcs-indexer}"
+readonly GOOGLE_CLOUD_SPANNER_INSTANCE
+GOOGLE_CLOUD_SPANNER_DATABASE="${GOOGLE_CLOUD_SPANNER_DATABASE:-gcs-indexer-db}"
+readonly GOOGLE_CLOUD_SPANNER_DATABASE
+
+# Enable (if they are not enabled already) the services will we will need
+gcloud services enable spanner.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+gcloud services enable cloudbuild.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+gcloud services enable container.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+gcloud services enable containerregistry.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+gcloud services enable run.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+gcloud services enable pubsub.googleapis.com \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+
+# Create a Cloud Spanner instance to host the GCS metadata index
+gcloud spanner instances create "${GOOGLE_CLOUD_SPANNER_INSTANCE}" \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    "--config=regional-${GOOGLE_CLOUD_REGION}" \
+    --description="Store the GCS metadata index" \
+    --nodes=3
+
+# Build the Docker Images
+gcloud builds submit \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    "--substitutions=SHORT_SHA=$(git rev-parse --short HEAD)" \
+    "--config=cloudbuild.yaml"
+
+# Create a service account for the Admin Deployment
+gcloud iam service-accounts create gcs-index-admin \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    --description="Perform administrative updates to the GCS metadata index"
+
+# Create a service account that will update the index
+readonly SA_ID="gcs-index-updater"
+readonly SA_NAME="${SA_ID}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+
+if gcloud iam service-accounts describe "${SA_NAME}" \
+               "--project=${GOOGLE_CLOUD_PROJECT}" >/dev/null 2>&1; then
+    echo "The service account ${SA_ID} already exists"
+else
+    gcloud iam service-accounts create "${SA_ID}" \
+        "--project=${GOOGLE_CLOUD_PROJECT}" \
+        --description="Perform updates to the GCS metadata index"
+
+    # Grant this service account permission to just update the table (but not
+    # create other tables or databases)
+    gcloud spanner instances add-iam-policy-binding \
+        "${GOOGLE_CLOUD_SPANNER_INSTANCE}" \
+        "--project=${GOOGLE_CLOUD_PROJECT}" \
+        "--member=serviceAccount:${SA_NAME}" \
+        "--role=roles/spanner.databaseUser"
+fi
+
+# Create the Cloud Run deployment to update the index
+gcloud beta run deploy gcs-indexer-pubsub-handler \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    "--service-account=${SA_NAME}" \
+    "--set-env-vars=SPANNER_PROJECT=${GOOGLE_CLOUD_PROJECT},SPANNER_INSTANCE=${GOOGLE_CLOUD_SPANNER_INSTANCE},SPANNER_DATABASE=${GOOGLE_CLOUD_SPANNER_DATABASE}" \
+    "--image=gcr.io/${GOOGLE_CLOUD_PROJECT}/gcs-indexer-pubsub-handler:latest" \
+    "--region=${GOOGLE_CLOUD_REGION}" \
+    "--platform=managed" \
+    "--no-allow-unauthenticated"
+
+# Capture the service URL.
+SERVICE_URL=$(gcloud beta run services list \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    "--platform=managed" \
+    '--format=csv[no-heading](URL)' \
+    "--filter=SERVICE:gcs-indexer-pubsub-handler")
+readonly SERVICE_URL
+
+# Create the Cloud Pub/Sub topic and configuration
+gcloud pubsub topics create gcs-indexer-updates \
+    "--project=${GOOGLE_CLOUD_PROJECT}"
+
+# Find out the project number as the service accounts used
+# are named based on this number.
+PROJECT_NUMBER=$(gcloud projects describe ${GOOGLE_CLOUD_PROJECT} \
+    --format='csv[no-heading](projectNumber)')
+readonly PROJECT_NUMBER
+
+# Grant the Cloud Pub/Sub service account permissions to make calls
+# on behalf of another account.
+PUBSUB_SA_NAME="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
+readonly PUBSUB_SA_NAME
+
+# To call the Cloud Run endpoint we need a OpenID token. We cannot obtain
+# such tokens for the for the Pub/Sub service account. We can create a special
+# service account, grant it access to call Cloud Run, and grant the Pub/Sub
+# service account permissions to create tokens for this account.
+gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
+    "--member=serviceAccount:${PUBSUB_SA_NAME}" \
+    "--role=roles/iam.serviceAccountTokenCreator"
+
+INVOKER_ID="gcs-indexer-run-invoker"
+INVOKER_NAME="${INVOKER_ID}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+readonly INVOKER_ID
+readonly INVOKER_NAME
+
+if gcloud iam service-accounts describe "$INVOKER_NAME}" >/dev/null 2>&1; then
+    echo "The service account ${INVOKER_ID} already exists"
+else
+    gcloud iam service-accounts create "${INVOKER_ID}" \
+        "--project=${GOOGLE_CLOUD_PROJECT}" \
+        --description="Calls the gcs-indexer in Cloud Run from Cloud Pub/Sub"
+fi
+
+cloud beta run services add-iam-policy-binding gcs-indexer-pubsub-handler \
+    "--project=${GOOGLE_CLOUD_PROJECT}" \
+    "--region=${GOOGLE_CLOUD_REGION}" \
+    "--platform=managed" \
+    "--member=serviceAccount:${INVOKER_NAME}" \
+    "--role=roles/run.invoker"
+
+# Configure Cloud Pub/Sub to push updates to our Cloud Run Deployment
+if gcloud pubsub subscriptions describe \
+    "projects/${GOOGLE_CLOUD_PROJECT}/subscriptions/run-subscription" >/dev/null 2>&1; then
+    echo "The subscription already exists"
+else
+    gcloud beta pubsub subscriptions create run-subscription \
+        "--topic-project=${GOOGLE_CLOUD_PROJECT}" \
+        "--topic=gcs-indexer-updates" \
+        "--push-endpoint=${SERVICE_URL}/" \
+        "--push-auth-service-account=${INVOKER_NAME}"
+fi
+
+# Create the GKE cluster
+if gcloud container clusters describe gcs-indexer \
+      "--project=${GOOGLE_CLOUD_PROJECT}" \
+      "--region=${GOOGLE_CLOUD_REGION}" >/dev/null 2>&1; then
+  echo "Cluster gcs-indexing already exists, reusing"
+else
+  gcloud container clusters create gcs-indexer \
+      "--project=${GOOGLE_CLOUD_PROJECT}" \
+      "--region=${GOOGLE_CLOUD_REGION}" \
+      "--preemptible" \
+      "--min-nodes=0" \
+      "--max-nodes=20" \
+      "--enable-autoscaling"
+fi
+
+gcloud container clusters get-credentials gcs-indexer \
+      "--project=${GOOGLE_CLOUD_PROJECT}" \
+      "--region=${GOOGLE_CLOUD_REGION}"
+
+if kubectl get secret service-account-key >/dev/null 2>&1; then
+    echo "The service account key for the ${SA_ID} service account already exists"
+else
+    KEY_FILE_DIR="/dev/shm"
+    if [[ ! -d "${KEY_FILE_DIR}" ]]; then
+       KEY_FILE_DIR="${HOME}"
+    fi
+
+    # Create new keys for this service account and download then to a temporary
+    # place:
+    gcloud iam service-accounts keys create "${KEY_FILE_DIR}/key.json" \
+        "--iam-account=${SA_NAME}"
+
+    # Copy the key to the GKE cluster:
+    kubectl create secret generic service-account-key \
+        "--from-file=key.json=${KEY_FILE_DIR}/key.json"
+
+    rm "${KEY_FILE_DIR}/key.json"
+fi
+
+exit 0

--- a/gcs-indexer/bootstrap-gcs-indexer.sh
+++ b/gcs-indexer/bootstrap-gcs-indexer.sh
@@ -155,7 +155,7 @@ else
         --description="Calls the gcs-indexer in Cloud Run from Cloud Pub/Sub"
 fi
 
-cloud beta run services add-iam-policy-binding gcs-indexer-pubsub-handler \
+gcloud beta run services add-iam-policy-binding gcs-indexer-pubsub-handler \
     "--project=${GOOGLE_CLOUD_PROJECT}" \
     "--region=${GOOGLE_CLOUD_REGION}" \
     "--platform=managed" \

--- a/gcs-indexer/ci/kokoro/build.sh
+++ b/gcs-indexer/ci/kokoro/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${SUBPROJECT_ROOT+x}" ]]; then
+  readonly SUBPROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+fi
+cd "${SUBPROJECT_ROOT}"
+
+# Verify the code compiles with Docker.
+if type -t docker>/dev/null; then
+  echo "================================================================"
+  echo "$(date -u): building Docker container for the code."
+  docker build -t unused-tag -f Dockerfile .
+  echo "================================================================"
+else
+  echo "Docker not found, skipping Docker tests."
+fi
+
+if type -t cmake>/dev/null && type -t ninja>/dev/null; then
+  echo "================================================================"
+  echo "$(date -u): building the code with CMake."
+  cmake -Hsuper -Bcmake-out -GNinja
+  cmake --build cmake-out
+else
+  echo "Missing cmake and ninja, skipping CMake Super Build."
+fi

--- a/gcs-indexer/ci/kokoro/build.sh
+++ b/gcs-indexer/ci/kokoro/build.sh
@@ -21,7 +21,7 @@ if [[ -z "${SUBPROJECT_ROOT+x}" ]]; then
 fi
 cd "${SUBPROJECT_ROOT}"
 
-# Verify the code compiles with Docker.
+# Verify the Dockerfile is working.
 if type -t docker>/dev/null; then
   echo "================================================================"
   echo "$(date -u): building Docker container for the code."
@@ -31,6 +31,7 @@ else
   echo "Docker not found, skipping Docker tests."
 fi
 
+# Verify the code compiles as a CMake Super Build.
 if type -t cmake>/dev/null && type -t ninja>/dev/null; then
   echo "================================================================"
   echo "$(date -u): building the code with CMake."

--- a/gcs-indexer/cloudbuild.yaml
+++ b/gcs-indexer/cloudbuild.yaml
@@ -1,0 +1,88 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Try to pull the image from the container registry, if it exists that can
+  # speed up the build because previous layers are reused.
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'docker pull gcr.io/${PROJECT_ID}/gcs-indexer-devtools || exit 0'
+  # Then create the `cloud-run-devtools` stage, using (if available) the
+  # image we just pulled as a cache. When there are no changes to the
+  # Dockerfile this caching can save 30 minutes or more.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '--target', 'devtools',
+           '-t', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools',
+           '-f', 'Dockerfile',
+           '.']
+    timeout: 3600s
+  # Push the work done so far to the container registry, if any of the
+  # subsequent steps fail, the build will restart from this point when we
+  # retry.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools:latest']
+
+  # Build the `build` stage, so we can reuse that in the next steps.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '-t', 'gcr.io/${PROJECT_ID}/gcs-indexer-build',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools',
+           '--target', 'build',
+           '-f', 'Dockerfile',
+           '.']
+
+  # Repeat the process to build the pubsub-handler stage.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '-t', 'gcr.io/${PROJECT_ID}/gcs-indexer-pubsub-handler',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-build',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools',
+           '--target', 'pubsub-handler',
+           '-f', 'Dockerfile',
+           '.']
+    timeout: 3600s
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['tag',
+           'gcr.io/${PROJECT_ID}/gcs-indexer-pubsub-handler:latest',
+           'gcr.io/${PROJECT_ID}/gcs-indexer-pubsub-handler:${SHORT_SHA}']
+    timeout: 3600s
+
+  # Repeat the process to build the tools stage.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '-t', 'gcr.io/${PROJECT_ID}/gcs-indexer-tools',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-build',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/gcs-indexer-devtools',
+           '--target', 'tools',
+           '-f', 'Dockerfile',
+           '.']
+    timeout: 3600s
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['tag',
+           'gcr.io/${PROJECT_ID}/gcs-indexer-tools:latest',
+           'gcr.io/${PROJECT_ID}/gcs-indexer-tools:${SHORT_SHA}']
+    timeout: 3600s
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+timeout: 7200s
+images:
+  - 'gcr.io/${PROJECT_ID}/gcs-indexer-pubsub-handler'
+  - 'gcr.io/${PROJECT_ID}/gcs-indexer-pubsub-handler:${SHORT_SHA}'
+  - 'gcr.io/${PROJECT_ID}/gcs-indexer-tools'
+  - 'gcr.io/${PROJECT_ID}/gcs-indexer-tools:${SHORT_SHA}'

--- a/gcs-indexer/create_database.cc
+++ b/gcs-indexer/create_database.cc
@@ -1,0 +1,122 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gcs_indexer_constants.h"
+#include <google/cloud/spanner/client.h>
+#include <google/cloud/spanner/database_admin_client.h>
+#include <boost/program_options.hpp>
+#include <algorithm>
+#include <deque>
+#include <iostream>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace spanner = google::cloud::spanner;
+
+int main(int argc, char* argv[]) try {
+  auto get_env = [](std::string_view name) -> std::string {
+    auto value = std::getenv(name.data());
+    return value == nullptr ? std::string{} : value;
+  };
+
+  auto default_thread_count = [](int thread_per_core) -> int {
+    auto const cores = std::thread::hardware_concurrency();
+    if (cores == 0) return thread_per_core;
+    return static_cast<int>(cores * thread_per_core);
+  };
+
+  // This magic value is approximately 20000 (the spanner limit for "things
+  // changed by a single transaction") divided by the number of columns affected
+  // by each object.
+  int const default_max_objects_per_mutation = 1200;
+
+  po::positional_options_description positional;
+  positional.add("bucket", -1);
+  po::options_description options("Create a GCS indexing database");
+  options.add_options()("help", "produce help message")
+      //
+      ("project",
+       po::value<std::string>()->default_value(get_env("GOOGLE_CLOUD_PROJECT")),
+       "set the Google Cloud Platform project id")
+      //
+      ("instance", po::value<std::string>()->required(),
+       "set the Cloud Spanner instance id")
+      //
+      ("database", po::value<std::string>()->required(),
+       "set the Cloud Spanner database id")
+      //
+      ("worker-threads",
+       po::value<unsigned int>()->default_value(default_thread_count(16)),
+       "the number of threads uploading data to Cloud Spanner");
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv)
+                .options(options)
+                .positional(positional)
+                .run(),
+            vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return 0;
+  }
+  for (auto arg : {"project", "instance", "database"}) {
+    if (vm.count(arg) != 1 || vm[arg].as<std::string>().empty()) {
+      std::cout << "The --" << arg
+                << " option must be set to a non-empty value\n"
+                << options << "\n";
+      return 1;
+    }
+  }
+  spanner::Database const database(vm["project"].as<std::string>(),
+                                   vm["instance"].as<std::string>(),
+                                   vm["database"].as<std::string>());
+
+  spanner::DatabaseAdminClient client;
+
+  std::string gcs_objects_table_ddl = R"sql(
+CREATE TABLE gcs_objects (
+  bucket STRING(128),
+  object STRING(1024),
+  generation STRING(128),
+  meta_generation STRING(128),
+  is_archived BOOL,
+  size INT64,
+  content_type STRING(256),
+  time_created TIMESTAMP,
+  updated TIMESTAMP,
+  storage_class STRING(256),
+  time_storage_class_updated TIMESTAMP,
+  md5_hash STRING(256),
+  crc32c STRING(256),
+  event_timestamp TIMESTAMP
+) PRIMARY KEY (bucket, object, generation)
+)sql";
+  auto created = client.CreateDatabase(database, {gcs_objects_table_ddl});
+  std::cout << "Waiting for database creation to complete " << std::flush;
+  for (;;) {
+    using namespace std::chrono_literals;
+    auto status = created.wait_for(1s);
+    if (status == std::future_status::ready) break;
+    std::cout << '.' << std::flush;
+  }
+  auto db = created.get().value();  // Throw on error.
+  std::cout << " DONE\n" << db.DebugString() << "\n";
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception caught " << ex.what() << '\n';
+  return 1;
+}

--- a/gcs-indexer/delete_index_for_bucket.cc
+++ b/gcs-indexer/delete_index_for_bucket.cc
@@ -76,19 +76,18 @@ int main(int argc, char* argv[]) try {
                                    vm["instance"].as<std::string>(),
                                    vm["database"].as<std::string>());
 
-  auto spanner_client = spanner::Client(spanner::MakeConnection(
-      std::move(database)));
+  auto spanner_client =
+      spanner::Client(spanner::MakeConnection(std::move(database)));
 
   for (auto const& bucket : vm["bucket"].as<std::vector<std::string>>()) {
-      std::cout << "Deleting data for bucket=<" << bucket << ">" << std::endl;
-      auto result = spanner_client.ExecutePartitionedDml(spanner::SqlStatement(
-          "DELETE FROM " + std::string(table_name) + " WHERE bucket = @bucket",
-          {{"bucket", spanner::Value(bucket)}}
-      ));
-      if (not result) {
-          std::cerr << "Error deleting index for bucket=<" << bucket << ">: "
-          << result.status() << "\n";
-      }
+    std::cout << "Deleting data for bucket=<" << bucket << ">" << std::endl;
+    auto result = spanner_client.ExecutePartitionedDml(spanner::SqlStatement(
+        "DELETE FROM " + std::string(table_name) + " WHERE bucket = @bucket",
+        {{"bucket", spanner::Value(bucket)}}));
+    if (not result) {
+      std::cerr << "Error deleting index for bucket=<" << bucket
+                << ">: " << result.status() << "\n";
+    }
   }
 
   return 0;

--- a/gcs-indexer/delete_index_for_bucket.cc
+++ b/gcs-indexer/delete_index_for_bucket.cc
@@ -1,0 +1,98 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gcs_indexer_constants.h"
+#include <google/cloud/spanner/client.h>
+#include <boost/program_options.hpp>
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace spanner = google::cloud::spanner;
+
+int main(int argc, char* argv[]) try {
+  auto get_env = [](std::string_view name) -> std::string {
+    auto value = std::getenv(name.data());
+    return value == nullptr ? std::string{} : value;
+  };
+
+  po::positional_options_description positional;
+  positional.add("bucket", -1);
+  po::options_description options("Create a GCS indexing database");
+  options.add_options()("help", "produce help message")
+      //
+      ("bucket", po::value<std::vector<std::string>>()->required(),
+       "the bucket to un-index")
+      //
+      ("project",
+       po::value<std::string>()->default_value(get_env("GOOGLE_CLOUD_PROJECT")),
+       "set the Google Cloud Platform project id")
+      //
+      ("instance", po::value<std::string>()->required(),
+       "set the Cloud Spanner instance id")
+      //
+      ("database", po::value<std::string>()->required(),
+       "set the Cloud Spanner database id");
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv)
+                .options(options)
+                .positional(positional)
+                .run(),
+            vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return 0;
+  }
+  for (auto arg : {"project", "instance", "database"}) {
+    if (vm.count(arg) != 1 || vm[arg].as<std::string>().empty()) {
+      std::cout << "The --" << arg
+                << " option must be set to a non-empty value\n"
+                << options << "\n";
+      return 1;
+    }
+  }
+  if (vm.count("bucket") == 0) {
+    std::cout << "You must specific at least one bucket to deindex\n"
+              << options << "\n";
+    return 1;
+  }
+
+  spanner::Database const database(vm["project"].as<std::string>(),
+                                   vm["instance"].as<std::string>(),
+                                   vm["database"].as<std::string>());
+
+  auto spanner_client = spanner::Client(spanner::MakeConnection(
+      std::move(database)));
+
+  for (auto const& bucket : vm["bucket"].as<std::vector<std::string>>()) {
+      std::cout << "Deleting data for bucket=<" << bucket << ">" << std::endl;
+      auto result = spanner_client.ExecutePartitionedDml(spanner::SqlStatement(
+          "DELETE FROM " + std::string(table_name) + " WHERE bucket = @bucket",
+          {{"bucket", spanner::Value(bucket)}}
+      ));
+      if (not result) {
+          std::cerr << "Error deleting index for bucket=<" << bucket << ">: "
+          << result.status() << "\n";
+      }
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception caught " << ex.what() << '\n';
+  return 1;
+}

--- a/gcs-indexer/gcs_indexer_constants.h
+++ b/gcs-indexer/gcs_indexer_constants.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DOCKER_RUN_CPP_GCS_INDEXER_CONSTANTS_H_
+#define DOCKER_RUN_CPP_GCS_INDEXER_CONSTANTS_H_
+
+#include <string>
+
+inline constexpr std::string_view table_name = "gcs_objects";
+inline constexpr char const* column_names[] = {
+    "bucket",
+    "object",
+    "generation",
+    "meta_generation",
+    "is_archived",
+    "size",
+    "content_type",
+    "time_created",
+    "updated",
+    "storage_class",
+    "time_storage_class_updated",
+    "md5_hash",
+    "crc32c",
+    "event_timestamp",
+};
+
+#endif  // DOCKER_RUN_CPP_GCS_INDEXER_CONSTANTS_H_

--- a/gcs-indexer/generate_randomly_named_objects.cc
+++ b/gcs-indexer/generate_randomly_named_objects.cc
@@ -87,8 +87,7 @@ std::vector<std::future<void>> launch_workers(std::string const& bucket,
         std::ostringstream os;
         os << "Prefix: " << prefix << "\nUse Hash Prefix: " << std::boolalpha
            << use_hash_prefix << "\nHashed Name: " << hashed
-           << "\nObject Index: " << i << "\nTask Id: " << task
-           << "\n";
+           << "\nObject Index: " << i << "\nTask Id: " << task << "\n";
         client.InsertObject(bucket, std::move(hashed), std::move(os).str())
             .value();
         ++total_object_count;

--- a/gcs-indexer/generate_randomly_named_objects.cc
+++ b/gcs-indexer/generate_randomly_named_objects.cc
@@ -1,0 +1,206 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/cloud/storage/client.h>
+#include <boost/program_options.hpp>
+#include <crc32c/crc32c.h>
+#include <functional>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace gcs = google::cloud::storage;
+
+std::atomic<std::int64_t> total_object_count;
+
+std::string random_name_portion(std::mt19937_64& gen, int n) {
+  static char const alphabet[] =
+      "abcdefghijklmnopqrstuvwxyz"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "0123456789"
+      "/-_.~@+=";
+  std::string result;
+  std::generate_n(std::back_inserter(result), n, [&gen] {
+    return alphabet[std::uniform_int_distribution<int>(
+        0, sizeof(alphabet) - 1)(gen)];
+  });
+  return result;
+}
+
+std::string random_prefix(std::mt19937_64& gen, std::string const& prefix) {
+  return prefix + random_name_portion(gen, 8);
+}
+
+std::string hashed_name(bool use_hash_prefix, std::string object_name) {
+  if (not use_hash_prefix) return std::move(object_name);
+
+  // Just use the last 32-bits of the hash
+  auto const hash = crc32c::Crc32c(object_name);
+
+  char buf[16];
+  std::snprintf(buf, sizeof(buf), "%08x_", hash);
+  return buf + object_name;
+}
+
+std::vector<std::future<void>> launch_workers(std::string const& bucket,
+                                              std::string const& prefix,
+                                              bool use_hash_prefix,
+                                              int task_count,
+                                              long object_count) {
+  if (object_count == 0) return {};
+  if (task_count == 0) return {};
+
+  std::vector<std::future<void>> tasks;
+  int task_id = 0;
+  std::generate_n(std::back_inserter(tasks), task_count, [&] {
+    int task = task_id++;
+    return std::async(std::launch::async, [=]() mutable {
+      std::mt19937_64 generator(std::random_device{}());
+      auto client = gcs::Client::CreateDefaultClient().value();
+      auto make_basename = [&generator, &prefix] {
+        auto basename = prefix;
+        if (not basename.empty()) basename += '/';
+        basename += random_name_portion(generator, 8);
+        basename += '-';
+        return basename;
+      };
+      std::string basename;
+      for (long i = 0; i != object_count; ++i) {
+        if (i % 100 == 0) basename = make_basename();
+        if (i % task_count != task) continue;
+        auto object_name = basename + std::to_string(i);
+        auto hashed = hashed_name(use_hash_prefix, std::move(object_name));
+        std::ostringstream os;
+        os << "Prefix: " << prefix << "\nUse Hash Prefix: " << std::boolalpha
+           << use_hash_prefix << "\nHashed Name: " << hashed
+           << "\nObject Index: " << i << "\nTask Id: " << task
+           << "\n";
+        client.InsertObject(bucket, std::move(hashed), std::move(os).str())
+            .value();
+        ++total_object_count;
+      }
+    });
+  });
+  return tasks;
+}
+
+std::vector<std::future<void>> launch_tasks(std::string const& bucket,
+                                            std::string const& prefix,
+                                            bool use_hash_prefix,
+                                            int task_count, long object_count) {
+  if (object_count == 0) return {};
+  if (task_count == 0) return {};
+  if (prefix.size() >= 512 or task_count == 1) {
+    return launch_workers(bucket, prefix, use_hash_prefix, task_count,
+                          object_count);
+  }
+
+  // Initialize a random bit source with some small amount of entropy.
+  std::mt19937_64 generator(std::random_device{}());
+  auto tasks = launch_tasks(bucket, random_prefix(generator, prefix),
+                            use_hash_prefix, task_count / 2, object_count / 2);
+  auto worker_tasks = launch_workers(bucket, prefix, use_hash_prefix,
+                                     task_count - task_count / 2,
+                                     object_count - object_count / 2);
+
+  tasks.insert(tasks.end(), std::move_iterator(worker_tasks.begin()),
+               std::move_iterator(worker_tasks.end()));
+  return tasks;
+}
+
+int main(int argc, char* argv[]) try {
+  unsigned int const default_task_count = []() -> unsigned int {
+    if (std::thread::hardware_concurrency() == 0) return 16;
+    return 16 * std::thread::hardware_concurrency();
+  }();
+  long const default_object_count = 1'000'000;
+
+  po::options_description desc(
+      "Populate a GCS Bucket with randomly named objects");
+  desc.add_options()("help", "produce help message")
+      //
+      ("bucket", po::value<std::string>()->required(),
+       "set the source bucket name")
+      //
+      ("object-count", po::value<long>()->default_value(default_object_count))
+      //
+      ("use-hash-prefix", po::value<bool>()->default_value(true))
+      //
+      ("task-count",
+       po::value<unsigned int>()->default_value(default_task_count));
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << desc << "\n";
+    return 0;
+  }
+  for (auto arg : {"bucket"}) {
+    if (vm.count(arg) != 1 || vm[arg].as<std::string>().empty()) {
+      std::cout << "The --" << arg
+                << " option must be set to a non-empty value\n"
+                << desc << "\n";
+      return 1;
+    }
+  }
+
+  auto const bucket = vm["bucket"].as<std::string>();
+  auto const use_hash_prefix = vm["use-hash-prefix"].as<bool>();
+  auto const task_count = vm["task-count"].as<unsigned int>();
+  auto const object_count = vm["object-count"].as<long>();
+
+  std::mt19937_64 generator(std::random_device{}());
+  auto const run_prefix = random_name_portion(generator, 16);
+
+  std::cout << "Creating " << object_count << " randomly named objects in "
+            << bucket << std::endl;
+  auto tasks = launch_tasks(bucket, run_prefix, use_hash_prefix, task_count,
+                            object_count);
+  std::cout << "Launched " << tasks.size() << " tasks... waiting" << std::endl;
+
+  auto report_progress =
+      [upload_start = std::chrono::steady_clock::now()](std::size_t active) {
+        using std::chrono::duration_cast;
+        using std::chrono::milliseconds;
+        auto count = total_object_count.load();
+        auto elapsed = std::chrono::steady_clock::now() - upload_start;
+        if (count == 0 or elapsed.count() == 0) return;
+        auto rate = count * 1000 / duration_cast<milliseconds>(elapsed).count();
+        std::cout << "  Uploaded " << count << " objects (" << rate
+                  << " objects/s, " << active << " task(s) still active)"
+                  << std::endl;
+      };
+  while (not tasks.empty()) {
+    using namespace std::chrono_literals;
+    auto& w = tasks.back();
+    auto status = w.wait_for(10s);
+    if (status == std::future_status::ready) {
+      tasks.pop_back();
+      continue;
+    }
+    report_progress(tasks.size());
+  }
+  report_progress(tasks.size());
+  std::cout << "DONE (" << total_object_count.load() << ")\n";
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception caught " << ex.what() << '\n';
+  return 1;
+}

--- a/gcs-indexer/generate_randomly_named_objects_config.py
+++ b/gcs-indexer/generate_randomly_named_objects_config.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Creates a k8s config to populate buckets."""
+
+import argparse
+import jinja2 as j2
+import os
+import time
+
+template = j2.Template("""
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-randomly-named-objects-{{timestamp}}
+spec:
+  parallelism: {{parallelism}}
+  completions: {{task_count}}
+  template:
+    metadata:
+      name: generate-randomly-named-objects-1
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: service-account-key
+          secret:
+            secretName: service-account-key
+      containers:
+        - name: gcs-indexer-tools
+          image: gcr.io/{{project_id}}/gcs-indexer-tools:latest
+          imagePullPolicy: Always
+          command: [
+              '/r/generate_randomly_named_objects',
+              '--object-count={{objects_per_task}}',
+              '--task-count={{generator_threads}}',
+              '--use-hash-prefix={{use_hash_prefix}}',
+              '--bucket={{bucket}}'
+          ]
+          resources:
+            requests:
+              cpu: '250m'
+              memory: '50Mi'
+          volumeMounts:
+            - name: service-account-key
+              mountPath: /var/secrets/service-account-key
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/service-account-key/key.json
+""")
+
+
+def check_positive(value):
+    as_int = int(value)
+    if as_int <= 0:
+        raise argparse.ArgumentTypeError(
+            '%s is not a valid positive integer value' % value)
+    return as_int
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--object-count', default=1_000_000, type=check_positive,
+                    help='the number of objects created by the k8s')
+parser.add_argument('--task-count', default=10, type=check_positive,
+                    help='the number of parallel tasks')
+parser.add_argument('--max-parallelism', default=10, type=check_positive,
+                    help='the maximum number of parallel tasks')
+parser.add_argument('--bucket', type=str, required=True,
+                    help='the GCS bucket where the objects are created')
+parser.add_argument('--use-hash-prefix', default=True, type=bool,
+                    help='use a hash prefix for each object name')
+parser.add_argument('--generator_threads', default=8, type=check_positive,
+                    help='the number of threads used by the generator')
+parser.add_argument('--project',
+                    default=os.environ.get('GOOGLE_CLOUD_PROJECT'),
+                    type=str, required=True,
+                    help='configure the Google Cloud Project')
+args = parser.parse_args()
+
+object_count = args.object_count
+task_count = args.task_count
+objects_per_task = max(int(object_count / task_count), 1)
+parallelism = min(task_count, args.max_parallelism)
+print(template.render(bucket=args.bucket, object_count=objects_per_task,
+                      objects_per_task=objects_per_task,
+                      generator_threads=args.generator_threads,
+                      use_hash_prefix=args.use_hash_prefix,
+                      project_id=args.project, parallelism=parallelism,
+                      task_count=task_count, timestamp=int(time.time())))

--- a/gcs-indexer/pubsub_handler.cc
+++ b/gcs-indexer/pubsub_handler.cc
@@ -1,0 +1,496 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gcs_indexer_constants.h"
+#include <google/cloud/spanner/client.h>
+#include <google/cloud/spanner/database_admin_client.h>
+#include <google/cloud/spanner/timestamp.h>
+#include <boost/archive/iterators/binary_from_base64.hpp>
+#include <boost/archive/iterators/transform_width.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <thread>
+
+namespace be = boost::beast;
+namespace asio = boost::asio;
+namespace po = boost::program_options;
+namespace pt = boost::property_tree;
+namespace spanner = google::cloud::spanner;
+using tcp = boost::asio::ip::tcp;
+
+inline constexpr int max_mutations = 1000;
+inline constexpr std::uint64_t KiB = 1024;
+inline constexpr auto request_body_size_limit = 32 * KiB;
+inline constexpr auto request_timeout = std::chrono::seconds(30);
+
+using row_type = std::tuple<std::string, std::string, std::string, bool,
+                            spanner::Timestamp, spanner::Timestamp>;
+using primary_key = std::tuple<std::string, std::string, std::string>;
+inline constexpr std::string_view event_finalize = "OBJECT_FINALIZE";
+inline constexpr std::string_view event_update = "OBJECT_METADATA_UPDATE";
+inline constexpr std::string_view event_delete = "OBJECT_DELETE";
+inline constexpr std::string_view event_archive = "OBJECT_ARCHIVE";
+
+// Report a failure
+void report_error(be::error_code ec, char const* what) {
+  std::cerr << what << ": " << ec.message() << "\n";
+}
+
+[[noreturn]] void throw_error(be::error_code ec, char const* what) {
+  std::ostringstream os;
+  os << what << ": " << ec.message() << "\n";
+  throw std::runtime_error(os.str());
+}
+
+/**
+ * Handle a HTTP request.
+ */
+class http_handler {
+ public:
+  explicit http_handler(spanner::Client client, spanner::Database database)
+      : client_(std::move(client)), database_(std::move(database)) {}
+
+  /**
+   * Handle a Google Cloud Storage Pub/Sub notification.
+   */
+  template <typename Body, typename Fields>
+  be::http::response<be::http::string_body> handle_gcs_notification(
+      be::http::request<Body, Fields> request) {
+    if (request[be::http::field::content_type] != "application/json") {
+      return bad_request(request, "invalid content-type for GCS notification");
+    }
+
+    std::function<void(std::string const& prefix, pt::ptree const& tree)>
+        dump_tree;
+
+    dump_tree = [&](std::string const& prefix, pt::ptree const& tree) {
+      for (auto& [k, v] : tree) {
+        auto p = prefix;
+        p += ".";
+        p += k;
+        std::cout << p << ":  " << v.data() << "\n";
+        auto sub_tree = tree.get_child(k, pt::ptree{});
+        dump_tree(p, sub_tree);
+      }
+    };
+
+    pt::ptree body = [&request] {
+      std::istringstream is(request.body());
+      pt::ptree tree;
+      pt::json_parser::read_json(is, tree);
+      return tree;
+    }();
+    // dump_tree("   body", body);
+
+    pt::ptree payload = [&body] {
+      std::string raw = body.get<std::string>("message.data", "");
+      namespace bai = boost::archive::iterators;
+      using binary_t =
+          bai::transform_width<bai::binary_from_base64<std::string::iterator>,
+                               8, 6>;
+      // Pad the raw string if needed.
+      raw.append((4 - raw.size() % 4) % 4, '=');
+      std::string data{binary_t(raw.begin()), binary_t(raw.end())};
+      // Boost.Property does not like characters after the closing brace.
+      data = data.substr(0, data.rfind('}') + 1);
+      std::istringstream is(data);
+      pt::ptree tree;
+      pt::json_parser::read_json(is, tree);
+      return tree;
+    }();
+    // dump_tree("   payload", payload);
+
+    auto const& attributes = body.get_child("message.attributes");
+
+    auto event_type = attributes.get<std::string>("eventType");
+    auto payload_format = attributes.get<std::string>("payloadFormat");
+    auto bucket = attributes.get<std::string>("bucketId");
+    auto object = attributes.get<std::string>("objectId");
+    auto generation = attributes.get<std::string>("objectGeneration");
+
+    std::cout << "event_type=" << event_type
+              << ", payload_format=" << payload_format << ", path=gs://"
+              << bucket << "/" << object << "/" << generation << std::endl;
+
+    // Acknowledge the notification, that frees up the Pub/Sub resources.
+    be::http::response<be::http::string_body> success{
+        be::http::status::no_content, request.version()};
+    success.set(be::http::field::server, BOOST_BEAST_VERSION_STRING);
+    success.set(be::http::field::content_type, "application/json");
+    success.keep_alive(request.keep_alive());
+    success.prepare_payload();
+
+    if (event_type == event_update) {
+      return success;
+    }
+
+    if (event_type == event_delete) {
+      auto mutation = spanner::MakeDeleteMutation(
+          std::string(table_name), spanner::KeySet().AddKey(spanner::MakeKey(
+                                       bucket, object, generation)));
+      client_
+          .Commit(
+              [m = std::move(mutation)](auto) { return spanner::Mutations{m}; })
+          .value();
+      return success;
+    }
+
+    auto columns = [] {
+      return std::vector<std::string>{std::begin(column_names),
+                                      std::end(column_names)};
+    };
+
+    if (event_type == event_archive || event_type == event_finalize) {
+      bool is_archived = event_type == event_archive;
+
+      auto update = spanner::MakeInsertOrUpdateMutation(
+          std::string(table_name), columns(), bucket, object, generation,
+          payload.get<std::string>("metaGeneration", ""), is_archived,
+          payload.get<std::int64_t>("size", 0),
+          payload.get<std::string>("contentType", ""),
+          spanner::internal::TimestampFromRFC3339(
+              payload.get<std::string>("timeCreated"))
+              .value(),
+          spanner::internal::TimestampFromRFC3339(
+              payload.get<std::string>("updated"))
+              .value(),
+          payload.get<std::string>("storageClass", ""),
+          spanner::internal::TimestampFromRFC3339(
+              payload.get<std::string>("timeStorageClassUpdated"))
+              .value(),
+          payload.get<std::string>("md5Hash", ""),
+          payload.get<std::string>("crc32c", ""),
+          spanner::MakeTimestamp(std::chrono::system_clock::now()).value());
+      client_
+          .Commit(
+              [m = std::move(update)](auto) { return spanner::Mutations{m}; })
+          .value();
+      return success;
+    }
+
+    return bad_request(request, "unknown event type");
+  }
+
+  template <typename Body, typename Fields>
+  be::http::response<be::http::string_body> handle_request(
+      be::http::request<Body, Fields> request) try {
+    if (request.method() == be::http::verb::post && request.target() == "/") {
+      return handle_gcs_notification(std::move(request));
+    }
+
+    if (request.method() != be::http::verb::get) {
+      return bad_request(request, "Unknown HTTP-method");
+    }
+
+    // Respond to GET request, mostly useful for debugging.
+    // TODO(...) - return an error, this is just for debugging.
+    be::http::response<be::http::string_body> res{be::http::status::ok,
+                                                  request.version()};
+    res.set(be::http::field::server, BOOST_BEAST_VERSION_STRING);
+    res.set(be::http::field::content_type, "text/plain");
+    res.keep_alive(request.keep_alive());
+    res.body() = "Hello World\n";
+    res.prepare_payload();
+    return res;
+  } catch (std::exception const& ex) {
+    std::ostringstream os;
+    os << "Exception caught in HTTP handler: " << ex.what();
+    std::cerr << os.str() << std::endl;
+    return internal_error(request, std::move(os).str());
+  }
+
+ private:
+  template <typename Body, typename Fields>
+  be::http::response<be::http::string_body> error_response(
+      be::http::request<Body, Fields> const& request, be::http::status status,
+      std::string_view text) {
+    be::http::response<be::http::string_body> res{status, request.version()};
+    res.set(be::http::field::server, BOOST_BEAST_VERSION_STRING);
+    res.set(be::http::field::content_type, "text/plain");
+    res.keep_alive(request.keep_alive());
+    res.body() = std::string(text);
+    res.prepare_payload();
+    return res;
+  }
+
+  template <typename Body, typename Fields>
+  be::http::response<be::http::string_body> bad_request(
+      be::http::request<Body, Fields> const& request, std::string_view text) {
+    return error_response(request, be::http::status::bad_request, text);
+  }
+
+  template <typename Body, typename Fields>
+  be::http::response<be::http::string_body> internal_error(
+      be::http::request<Body, Fields> const& request, std::string_view text) {
+    return error_response(request, be::http::status::internal_server_error,
+                          text);
+  }
+
+  spanner::Client client_;
+  spanner::Database database_;
+};
+
+/**
+ * Handle a HTTP session.
+ */
+class http_session : public std::enable_shared_from_this<http_session> {
+ public:
+  explicit http_session(tcp::socket socket,
+                        std::shared_ptr<http_handler> handler)
+      : stream_(std::move(socket)), handler_(std::move(handler)) {}
+
+  void start() {
+    parser_.emplace();
+    parser_->body_limit(request_body_size_limit);
+    stream_.expires_after(request_timeout);
+
+    be::http::async_read(
+        stream_, buffer_, *parser_,
+        [self = shared_from_this()](be::error_code ec, std::size_t s) {
+          self->on_read(ec, s);
+        });
+  }
+
+ private:
+  void on_read(be::error_code ec, std::size_t /*bytes_transferred*/) {
+    // End of stream is expected, simply close the socket and return.
+    if (ec == be::http::error::end_of_stream) return close();
+
+    // Other errors are unexpected, just report the error and let the socket
+    // close.
+    if (ec) return report_error(ec, "on_read");
+
+    auto send = [this](auto response) {
+      // We need to hold the response object until the async_write() below
+      // completes. Create an object to hold the response, and make the
+      // callback the owner of it.
+      using response_type = std::decay_t<decltype(response)>;
+      struct pending_response {
+        pending_response(std::shared_ptr<http_session> s, response_type r)
+            : session(std::move(s)), response(std::move(r)) {}
+
+        std::shared_ptr<http_session> session;
+        response_type response;
+      };
+      auto pr = std::make_shared<pending_response>(shared_from_this(),
+                                                   std::move(response));
+      be::http::async_write(stream_, pr->response, [pr](auto ec, auto s) {
+        pr->session->on_write(pr->response.need_eof(), ec, s);
+      });
+    };
+
+    send(handler_->handle_request(std::move(parser_->release())));
+  }
+
+  void on_write(bool need_eof, be::error_code ec,
+                std::size_t /*bytes_transferred*/) {
+    if (ec) return report_error(ec, "on_write");
+    if (need_eof) close();
+    // Read the next request.
+    start();
+  }
+
+  void close() {
+    be::error_code ec;
+    stream_.socket().shutdown(tcp::socket::shutdown_send, ec);
+  }
+
+  be::tcp_stream stream_;
+  std::shared_ptr<http_handler> handler_;
+  be::flat_buffer buffer_;
+
+  // The parser is stored in an optional container so we can
+  // construct it from scratch it at the beginning of each new message.
+  std::optional<be::http::request_parser<be::http::string_body>> parser_;
+};
+
+/**
+ * Accept HTTP sessions.
+ */
+class acceptor : public std::enable_shared_from_this<acceptor> {
+ public:
+  acceptor(asio::io_context& ioc, tcp::endpoint const& endpoint,
+           std::shared_ptr<http_handler> handler)
+      : ioc_(ioc),
+        socket_acceptor_(asio::make_strand(ioc_)),
+        handler_(std::move(handler)) {
+    be::error_code ec;
+
+    // Open the acceptor
+    socket_acceptor_.open(endpoint.protocol(), ec);
+    if (ec) {
+      throw_error(ec, "open");
+    }
+
+    // Allow address reuse
+    socket_acceptor_.set_option(asio::socket_base::reuse_address(true), ec);
+    if (ec) {
+      throw_error(ec, "set_option");
+    }
+
+    // Bind to the server address
+    socket_acceptor_.bind(endpoint, ec);
+    if (ec) {
+      throw_error(ec, "bind");
+    }
+
+    // Start listening for connections
+    socket_acceptor_.listen(asio::socket_base::max_listen_connections, ec);
+    if (ec) {
+      throw_error(ec, "listen");
+    }
+  }
+
+  void start() {
+    socket_acceptor_.async_accept(
+        asio::make_strand(ioc_),
+        [self = shared_from_this()](be::error_code const& ec, tcp::socket s) {
+          self->on_accept(ec, std::move(s));
+        });
+  }
+
+ private:
+  void on_accept(be::error_code ec, tcp::socket socket) {
+    if (ec) {
+      report_error(ec, "on_accept");
+    } else {
+      std::make_shared<http_session>(std::move(socket), handler_)->start();
+    }
+    start();
+  }
+
+  asio::io_context& ioc_;
+  tcp::acceptor socket_acceptor_;
+  std::shared_ptr<http_handler> handler_;
+};
+
+int main(int argc, char* argv[]) try {
+  auto const default_threads = [] {
+    auto count = std::thread::hardware_concurrency();
+    return count == 0 ? 1 : static_cast<int>(count);
+  }();
+
+  auto get_env = [](std::string_view name) -> std::string {
+    auto value = std::getenv(name.data());
+    return value == nullptr ? std::string{} : value;
+  };
+
+  auto port = [&]() -> std::uint16_t {
+    auto env = get_env("PORT");
+    if (env.empty()) return 8080;
+    auto value = std::stoi(env);
+    if (value < std::numeric_limits<std::uint16_t>::min() ||
+        value > std::numeric_limits<std::uint16_t>::max()) {
+      std::ostringstream os;
+      os << "The PORT environment variable value (" << value
+         << ") is out of range.";
+      throw std::invalid_argument(std::move(os).str());
+    }
+    return static_cast<std::uint16_t>(value);
+  }();
+
+  po::options_description desc("Server configuration");
+  desc.add_options()
+      //
+      ("help", "produce help message")(
+          "address", po::value<std::string>()->default_value("0.0.0.0"),
+          "set listening address")
+      //
+      ("port", po::value<std::uint16_t>(&port), "set listening port")
+      //
+      ("threads", po::value<int>()->default_value(default_threads),
+       "set the number of I/O threads")
+      //
+      ("project",
+       po::value<std::string>()->default_value(get_env("GOOGLE_CLOUD_PROJECT")),
+       "set the Google Cloud Platform project id")
+      //
+      ("instance", po::value<std::string>()->required(),
+       "set the Cloud Spanner instance id")
+      //
+      ("database", po::value<std::string>()->required(),
+       "set the Cloud Spanner database id");
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << desc << "\n";
+    return 0;
+  }
+  for (auto arg : {"project", "instance", "database"}) {
+    if (vm.count(arg) != 1 || vm[arg].as<std::string>().empty()) {
+      std::cout << "The --" << arg
+                << " option must be set to a non-empty value\n"
+                << desc << "\n";
+      return 1;
+    }
+  }
+
+  auto address = asio::ip::make_address(vm["address"].as<std::string>());
+  auto threads = vm["threads"].as<int>();
+  spanner::Database database(vm["project"].as<std::string>(),
+                             vm["instance"].as<std::string>(),
+                             vm["database"].as<std::string>());
+
+  std::cout << "Listening on " << address << ":" << port << " using " << threads
+            << " threads\n"
+            << "Will update object index in database: " << database
+            << std::endl;
+
+  asio::io_context ioc{threads};
+  // Capture SIGINT and SIGTERM to perform a clean shutdown
+  asio::signal_set signals(ioc, SIGINT, SIGTERM);
+  signals.async_wait([&](auto, auto) {
+    // Stop the `io_context`. This will cause `run()`
+    // to return immediately, eventually destroying the
+    // `io_context` and all of the sockets in it.
+    ioc.stop();
+  });
+
+  spanner::Client client(spanner::MakeConnection(database));
+
+  auto acc = std::make_shared<acceptor>(
+      ioc, tcp::endpoint{address, port},
+      std::make_shared<http_handler>(std::move(client), std::move(database)));
+  acc->start();
+
+  std::vector<std::thread> v(threads - 1);
+  std::generate_n(v.begin(), v.size(),
+                  [&ioc] { return std::thread([&ioc] { ioc.run(); }); });
+  // Block also the main thread, reaching the designed count.
+  ioc.run();
+
+  // Block until all the threads exit
+  for (auto& t : v) {
+    t.join();
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception caught " << ex.what() << '\n';
+  return 1;
+}

--- a/gcs-indexer/refresh-index.sh
+++ b/gcs-indexer/refresh-index.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <prefix> [prefix ...]"
+  echo "  A prefix can be a bucket name (without the gs://)"
+  echo "  or a bucket name and a object name prefix, separated by /"
+  exit 1
+fi
+
+if [[ -z "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
+  echo "You must set GOOGLE_CLOUD_PROJECT to the project id hosting the GCS" \
+      "metadata indexer"
+  exit 1
+fi
+
+GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-}"
+readonly GOOGLE_CLOUD_PROJECT
+GOOGLE_CLOUD_SPANNER_INSTANCE="${GOOGLE_CLOUD_SPANNER_INSTANCE:-gcs-indexer}"
+readonly GOOGLE_CLOUD_SPANNER_INSTANCE
+GOOGLE_CLOUD_SPANNER_DATABASE="${GOOGLE_CLOUD_SPANNER_DATABASE:-gcs-indexer-db}"
+readonly GOOGLE_CLOUD_SPANNER_DATABASE
+
+# Create a GKE job to refresh each prefix
+for prefix in "${@}"; do
+  ./refresh_index_for_bucket_config.py \
+      "--project=${GOOGLE_CLOUD_PROJECT}" \
+      "--instance=${GOOGLE_CLOUD_SPANNER_INSTANCE}" \
+      "--database=${GOOGLE_CLOUD_SPANNER_DATABASE}" \
+      "${prefix}" | kubectl apply -f -
+done
+
+exit 0

--- a/gcs-indexer/refresh_index_for_bucket.cc
+++ b/gcs-indexer/refresh_index_for_bucket.cc
@@ -1,0 +1,392 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gcs_indexer_constants.h"
+#include <google/cloud/spanner/client.h>
+#include <google/cloud/storage/client.h>
+#include <boost/program_options.hpp>
+#include <algorithm>
+#include <deque>
+#include <iostream>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace spanner = google::cloud::spanner;
+namespace gcs = google::cloud::storage;
+
+struct work_item {
+  std::string bucket;
+  std::string prefix;
+};
+
+work_item make_work_item(std::string const& p) {
+  auto pos = p.find_first_of('/');
+  auto bucket = p.substr(0, pos);
+  auto prefix = pos == std::string::npos ? std::string{} : p.substr(pos + 1);
+  return {std::move(bucket), std::move(prefix)};
+}
+
+template <typename T>
+class bounded_queue {
+ public:
+  bounded_queue() : bounded_queue(512, 1024) {}
+  explicit bounded_queue(std::size_t lwm, std::size_t hwm)
+      : lwm_(lwm), hwm_(hwm) {}
+
+  void shutdown() {
+    std::unique_lock<std::mutex> lk(mu_);
+    is_shutdown_ = true;
+    lk.unlock();
+    cv_read_.notify_all();
+    cv_write_.notify_all();
+  }
+
+  std::optional<T> pop() {
+    std::unique_lock<std::mutex> lk(mu_);
+    reader_wait(lk, [this] { return is_shutdown_ or not empty(); });
+    // Even if `is_shutdown_` is true we need to drain any remaining
+    // items.
+    if (empty()) return {};
+    auto next = std::move(buffer_.back());
+    buffer_.pop_back();
+    ++pop_count_;
+    if (below_lwm() and has_writers()) {
+      cv_write_.notify_all();
+    }
+    if (not empty() and has_readers()) {
+      cv_read_.notify_one();
+    }
+    lk.unlock();
+    return next;
+  }
+
+  void push(T data) {
+    std::unique_lock<std::mutex> lk(mu_);
+    writer_wait(lk, [this] { return is_shutdown_ or below_hwm(); });
+    if (is_shutdown_) return;
+    buffer_.push_back(std::move(data));
+    ++push_count_;
+    max_depth_ = (std::max)(max_depth_, buffer_.size());
+    if (has_readers()) {
+      cv_read_.notify_one();
+    }
+  }
+
+  void print_stats(std::ostream& os) {
+    std::lock_guard<std::mutex> lk(mu_);
+    os << "push_count=" << push_count_ << ", pop_count=" << pop_count_
+       << ", max_depth=" << max_depth_ << ", current_depth=" << buffer_.size()
+       << ", reader_count=" << reader_count_ << ", max_readers=" << max_readers_
+       << ", writer_count=" << writer_count_ << ", max_writers=" << max_writers_
+       << ", hwm_=" << hwm_ << ", lwm_=" << lwm_
+       << ", is_shutdown=" << is_shutdown_;
+  }
+
+ private:
+  [[nodiscard]] bool empty() const { return buffer_.empty(); }
+  [[nodiscard]] bool below_hwm() const { return buffer_.size() <= hwm_; }
+  [[nodiscard]] bool below_lwm() const { return buffer_.size() <= lwm_; }
+  [[nodiscard]] bool has_readers() const { return reader_count_ > 0; }
+  [[nodiscard]] bool has_writers() const { return writer_count_ > 0; }
+
+  template <typename Predicate>
+  void writer_wait(std::unique_lock<std::mutex>& lk, Predicate&& p) {
+    ++writer_count_;
+    max_writers_ = (std::max)(max_writers_, writer_count_);
+    cv_write_.wait(lk, std::forward<Predicate>(p));
+    --writer_count_;
+  }
+
+  template <typename Predicate>
+  void reader_wait(std::unique_lock<std::mutex>& lk, Predicate&& p) {
+    ++reader_count_;
+    max_readers_ = (std::max)(max_readers_, reader_count_);
+    cv_read_.wait(lk, std::forward<Predicate>(p));
+    --reader_count_;
+  }
+
+ private:
+  std::size_t const lwm_;
+  std::size_t const hwm_;
+
+  std::mutex mu_;
+  std::condition_variable cv_read_;
+  std::condition_variable cv_write_;
+  std::vector<T> buffer_;
+  bool is_shutdown_ = false;
+  int reader_count_ = 0;
+  int writer_count_ = 0;
+  int max_readers_ = 0;
+  int max_writers_ = 0;
+  std::size_t max_depth_ = 0;
+  std::size_t push_count_ = 0;
+  std::size_t pop_count_ = 0;
+};
+
+std::atomic<std::uint64_t> total_read_count;
+std::atomic<std::uint64_t> total_insert_count;
+
+void process_vector(std::vector<gcs::ObjectMetadata> const& objects,
+                    spanner::Client spanner_client, spanner::Timestamp start,
+                    bool discard_output) {
+  if (objects.empty()) return;
+
+  spanner_client
+      .Commit([&objects, start, discard_output](auto) {
+        static auto const columns = [] {
+          return std::vector<std::string>{std::begin(column_names),
+                                          std::end(column_names)};
+        }();
+        spanner::InsertOrUpdateMutationBuilder builder{std::string(table_name),
+                                                       columns};
+
+        int count = 0;
+        for (auto const& object : objects) {
+          bool is_archived =
+              object.time_deleted().time_since_epoch().count() != 0;
+          builder.EmplaceRow(
+              object.bucket(), object.name(),
+              std::to_string(object.generation()), object.metageneration(),
+              is_archived, static_cast<std::int64_t>(object.size()),
+              object.content_type(),
+              spanner::MakeTimestamp(object.time_created()).value(),
+              spanner::MakeTimestamp(object.updated()).value(),
+              object.storage_class(),
+              spanner::MakeTimestamp(object.time_storage_class_updated())
+                  .value(),
+              object.md5_hash(), object.crc32c(), start);
+        }
+        if (discard_output) return spanner::Mutations{};
+        return spanner::Mutations{std::move(builder).Build()};
+      })
+      .value();
+  total_insert_count.fetch_add(objects.size());
+}
+
+using object_metadata_queue = bounded_queue<std::vector<gcs::ObjectMetadata>>;
+using work_item_queue = bounded_queue<work_item>;
+
+void insert_worker(object_metadata_queue& queue, spanner::Database database,
+                   spanner::Timestamp start, bool discard_output) {
+  std::ostringstream pool_id;
+  pool_id << std::this_thread::get_id();
+  auto spanner_client = spanner::Client(spanner::MakeConnection(
+      std::move(database),
+      spanner::ConnectionOptions{}.set_num_channels(1).set_channel_pool_domain(
+          std::move(pool_id).str()),
+      spanner::SessionPoolOptions{}.set_min_sessions(1)));
+  for (auto v = queue.pop(); v.has_value(); v = queue.pop()) {
+    process_vector(*v, spanner_client, start, discard_output);
+  }
+}
+
+void list_worker(object_metadata_queue& dst, work_item_queue& src,
+                 int max_objects_per_mutation, bool discard_input) {
+  auto gcs_client = gcs::Client::CreateDefaultClient().value();
+
+  for (auto item = src.pop(); item.has_value(); item = src.pop()) {
+    auto prefix_option =
+        item->prefix.empty() ? gcs::Prefix{} : gcs::Prefix(item->prefix);
+    std::vector<gcs::ObjectMetadata> buffer;
+    auto flush = [&](bool force) {
+      if (buffer.empty()) return;
+      // TODO(...) - we should use a better estimation of the mutation cost,
+      //    e.g. the number of columns affected.
+      if (not force and buffer.size() < max_objects_per_mutation) return;
+      if (not discard_input) dst.push(std::move(buffer));
+      buffer.clear();
+    };
+    for (auto& o : gcs_client.ListObjects(
+             item->bucket, std::move(prefix_option), gcs::Versions{true})) {
+      if (not o) break;
+      buffer.push_back(*std::move(o));
+      ++total_read_count;
+      flush(false);
+    }
+    flush(true);
+  }
+}
+
+int main(int argc, char* argv[]) try {
+  auto get_env = [](std::string_view name) -> std::string {
+    auto value = std::getenv(name.data());
+    return value == nullptr ? std::string{} : value;
+  };
+
+  auto default_thread_count = [](int thread_per_core) -> int {
+    auto const cores = std::thread::hardware_concurrency();
+    if (cores == 0) return thread_per_core;
+    return static_cast<int>(cores * thread_per_core);
+  };
+
+  // This magic value is approximately 20000 (the spanner limit for "things
+  // changed by a single transaction") divided by the number of columns affected
+  // by each object.
+  int const default_max_objects_per_mutation = 1200;
+
+  po::positional_options_description positional;
+  positional.add("bucket", -1);
+  po::options_description options("Create a GCS indexing database");
+  options.add_options()("help", "produce help message")
+      //
+      ("bucket", po::value<std::vector<std::string>>()->required(),
+       "the bucket to refresh, use [BUCKET_NAME]/[PREFIX] to upload only a"
+       " prefix")
+      //
+      ("project",
+       po::value<std::string>()->default_value(get_env("GOOGLE_CLOUD_PROJECT")),
+       "set the Google Cloud Platform project id")
+      //
+      ("instance", po::value<std::string>()->required(),
+       "set the Cloud Spanner instance id")
+      //
+      ("database", po::value<std::string>()->required(),
+       "set the Cloud Spanner database id")
+      //
+      ("worker-threads",
+       po::value<unsigned int>()->default_value(default_thread_count(16)),
+       "the number of threads uploading data to Cloud Spanner")
+      //
+      ("reader-threads",
+       po::value<unsigned int>()->default_value(default_thread_count(4)),
+       "the number of threads reading data from Google Cloud Storage")
+      //
+      ("discard-input", po::value<bool>()->default_value(false),
+       "discard all data read from GCS, used for testing")
+      //
+      ("discard-output", po::value<bool>()->default_value(false),
+       "discard data before sending it to Cloud Spanner, used for testing")
+      //
+      ("max-objects-per-mutation",
+       po::value<int>()->default_value(default_max_objects_per_mutation));
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv)
+                .options(options)
+                .positional(positional)
+                .run(),
+            vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return 0;
+  }
+  for (auto arg : {"project", "instance", "database"}) {
+    if (vm.count(arg) != 1 || vm[arg].as<std::string>().empty()) {
+      std::cout << "The --" << arg
+                << " option must be set to a non-empty value\n"
+                << options << "\n";
+      return 1;
+    }
+  }
+  if (vm.count("bucket") == 0) {
+    std::cout << "You must specific at least one bucket to refresh\n"
+              << options << "\n";
+    return 1;
+  }
+  auto const worker_thread_count = vm["worker-threads"].as<unsigned int>();
+  auto const reader_thread_count = vm["reader-threads"].as<unsigned int>();
+
+  spanner::Database const database(vm["project"].as<std::string>(),
+                                   vm["instance"].as<std::string>(),
+                                   vm["database"].as<std::string>());
+
+  auto const start =
+      spanner::MakeTimestamp(std::chrono::system_clock::now()).value();
+  auto const max_objects_per_mutation =
+      vm["max-objects-per-mutation"].as<int>();
+
+  object_metadata_queue object_queue;
+  work_item_queue work_queue;
+
+  std::cout << "Starting worker threads [" << worker_thread_count << "]" << std::endl;
+  std::vector<std::future<void>> workers;
+  std::generate_n(std::back_inserter(workers), worker_thread_count,
+                  [&database, start, &object_queue,
+                   discard_output = vm["discard-output"].as<bool>()] {
+                    return std::async(std::launch::async, insert_worker,
+                                      std::ref(object_queue), database, start,
+                                      discard_output);
+                  });
+
+  std::cout << "Starting reader threads [" << reader_thread_count << "]" << std::endl;
+  std::vector<std::future<void>> readers;
+  std::generate_n(std::back_inserter(readers), reader_thread_count,
+                  [&work_queue, &object_queue, max_objects_per_mutation,
+                   discard_input = vm["discard-input"].as<bool>()] {
+                    return std::async(std::launch::async, list_worker,
+                                      std::ref(object_queue),
+                                      std::ref(work_queue),
+                                      max_objects_per_mutation, discard_input);
+                  });
+
+  auto report_progress = [&object_queue,
+                          upload_start = std::chrono::steady_clock::now()](
+                             std::size_t active) {
+    using std::chrono::duration_cast;
+    using std::chrono::milliseconds;
+    auto read_count = total_read_count.load();
+    auto insert_count = total_insert_count.load();
+    auto elapsed = std::chrono::steady_clock::now() - upload_start;
+    if ((read_count == 0 and insert_count == 0) or elapsed.count() == 0) return;
+    auto log = [elapsed](char const* action, std::uint64_t count) {
+      auto rate = count * 1000 / duration_cast<milliseconds>(elapsed).count();
+      std::cout << "  " << action << " " << count << " objects (" << rate
+                << " objects/s)\n";
+    };
+    log("Read", read_count);
+    log("Upload", insert_count);
+    std::cout << "  " << active << " task(s) still active, queue={";
+    object_queue.print_stats(std::cout);
+    std::cout << "}\n";
+  };
+
+  std::cout << "Populating work queue" << std::endl;
+  for (auto const& p : vm["bucket"].as<std::vector<std::string>>()) {
+    work_queue.push(make_work_item(p));
+  }
+  // Tell the workers that no more data is coming so they can exit.
+  work_queue.shutdown();
+
+  auto wait_for_tasks = [&report_progress](std::vector<std::future<void>> tasks,
+                                           std::size_t base_task_count) {
+    while (not tasks.empty()) {
+      using namespace std::chrono_literals;
+      using std::chrono::duration_cast;
+      auto& w = tasks.back();
+      auto status = w.wait_for(10s);
+      if (status == std::future_status::ready) {
+        tasks.pop_back();
+        continue;
+      }
+      report_progress(tasks.size() + base_task_count);
+    }
+    report_progress(tasks.size() + base_task_count);
+  };
+
+  std::cout << "Waiting for readers" << std::endl;
+  wait_for_tasks(std::move(readers), workers.size());
+  object_queue.shutdown();
+
+  std::cout << "Waiting for writers" << std::endl;
+  wait_for_tasks(std::move(workers), 0);
+
+  std::cout << "DONE\n";
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception caught " << ex.what() << '\n';
+  return 1;
+}

--- a/gcs-indexer/refresh_index_for_bucket.cc
+++ b/gcs-indexer/refresh_index_for_bucket.cc
@@ -95,9 +95,17 @@ class bounded_queue {
 
  private:
   [[nodiscard]] bool empty() const { return buffer_.empty(); }
-  [[nodiscard]] bool below_hwm() const { return buffer_.size() <= hwm_; }
+
+      [[nodiscard]] bool below_hwm() const {
+    return buffer_.size() <= hwm_;
+  }
+
   [[nodiscard]] bool below_lwm() const { return buffer_.size() <= lwm_; }
-  [[nodiscard]] bool has_readers() const { return reader_count_ > 0; }
+
+      [[nodiscard]] bool has_readers() const {
+    return reader_count_ > 0;
+  }
+
   [[nodiscard]] bool has_writers() const { return writer_count_ > 0; }
 
   template <typename Predicate>
@@ -311,7 +319,8 @@ int main(int argc, char* argv[]) try {
   object_metadata_queue object_queue;
   work_item_queue work_queue;
 
-  std::cout << "Starting worker threads [" << worker_thread_count << "]" << std::endl;
+  std::cout << "Starting worker threads [" << worker_thread_count << "]"
+            << std::endl;
   std::vector<std::future<void>> workers;
   std::generate_n(std::back_inserter(workers), worker_thread_count,
                   [&database, start, &object_queue,
@@ -321,7 +330,8 @@ int main(int argc, char* argv[]) try {
                                       discard_output);
                   });
 
-  std::cout << "Starting reader threads [" << reader_thread_count << "]" << std::endl;
+  std::cout << "Starting reader threads [" << reader_thread_count << "]"
+            << std::endl;
   std::vector<std::future<void>> readers;
   std::generate_n(std::back_inserter(readers), reader_thread_count,
                   [&work_queue, &object_queue, max_objects_per_mutation,

--- a/gcs-indexer/refresh_index_for_bucket_config.py
+++ b/gcs-indexer/refresh_index_for_bucket_config.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Creates a k8s config to run a single refresh_bucket task."""
+
+import argparse
+import jinja2 as j2
+import os
+import random
+import time
+
+template = j2.Template("""
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: refresh-bucket-{{timestamp}}-{{random}}
+spec:
+  completions: 1
+  template:
+    metadata:
+      name: refresh-bucket-worker
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: service-account-key
+          secret:
+            secretName: service-account-key
+      containers:
+        - name: gcs-indexer-tools
+          image: gcr.io/{{project_id}}/gcs-indexer-tools:latest
+          imagePullPolicy: Always
+          command: [
+              '/r/refresh_index_for_bucket',
+              '--project={{project_id}}',
+              '--instance={{instance}}',
+              '--database={{database}}',
+              '--reader-threads={{reader_threads}}',
+              '--worker-threads={{worker_threads}}',
+              {{ prefixes|join(', ') }}
+          ]
+          volumeMounts:
+            - name: service-account-key
+              mountPath: /var/secrets/service-account-key
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/service-account-key/key.json
+""")
+
+
+def check_positive(value):
+    as_int = int(value)
+    if as_int <= 0:
+        raise argparse.ArgumentTypeError(
+            '%s is not a valid positive integer value' % value)
+    return as_int
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--project',
+                    default=os.environ.get('GOOGLE_CLOUD_PROJECT'),
+                    type=str, required=True,
+                    help='configure the Google Cloud Project')
+parser.add_argument('--instance',
+                    type=str, required=True,
+                    help='configure the Cloud Spanner instance id')
+parser.add_argument('--database',
+                    type=str, required=True,
+                    help='configure the Cloud Spanner database id')
+parser.add_argument('prefixes', type=str, nargs='+',
+                    help='the GCS bucket where the objects are created')
+args = parser.parse_args()
+
+reader_threads = 2 if len(args.prefixes) > 1 else 1
+worker_threads = 8 if len(args.prefixes) > 1 else 4
+
+print(template.render(project_id=args.project, instance=args.instance, database=args.database,
+                      reader_threads=reader_threads, worker_threads=worker_threads,
+                      prefixes=["'%s'" % prefix for prefix in args.prefixes],
+                      timestamp=int(time.time()), random=random.randint(0, 100000)))

--- a/gcs-indexer/sample-queries.md
+++ b/gcs-indexer/sample-queries.md
@@ -1,0 +1,24 @@
+# Sample Queries for DB
+
+```{sql}
+WITH dups AS (
+SELECT size
+     , crc32c
+     , COUNT(*) AS copies
+  FROM gcs_objects
+ WHERE bucket = 'coryan-test-large-bucket-1000000'
+ GROUP BY size, crc32c
+HAVING copies > 1
+  )
+SELECT o.bucket
+     , o.object
+     , o.size
+     , o.crc32c
+     , o.md5_hash
+  FROM gcs_objects AS o, dups AS d
+ WHERE o.bucket = 'coryan-test-large-bucket-1000000'
+   AND o.size = d.size
+   AND o.crc32c = d.crc32c
+ ORDER BY o.crc32c, o.size
+     ;
+```

--- a/gcs-indexer/super/CMakeLists.txt
+++ b/gcs-indexer/super/CMakeLists.txt
@@ -1,0 +1,69 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.10)
+project(cloud-run-cpp-build CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CLOUD_RUN_CPP_ROOT "${PROJECT_SOURCE_DIR}/..")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+
+include(external/external-project-helpers)
+include(external/google-cloud-cpp-common)
+include(external/google-cloud-cpp)
+include(external/google-cloud-cpp-spanner)
+include(external/boost)
+
+set(GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST
+    google-cloud-cpp-spanner-project
+        google-cloud-cpp-project
+        google-cloud-cpp-common-project
+        boost-project)
+
+google_cloud_cpp_set_prefix_vars()
+message("-DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+message("-DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+externalproject_add(
+    google-run-cpp-project
+    DEPENDS ${GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST}
+    EXCLUDE_FROM_ALL OFF
+    PREFIX "${CMAKE_BINARY_DIR}"
+    INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+    SOURCE_DIR
+    "${CLOUD_RUN_CPP_ROOT}"
+    LIST_SEPARATOR
+    |
+    BUILD_ALWAYS ON
+    CMAKE_ARGS -G${CMAKE_GENERATOR}
+               -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+               -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+               -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    BUILD_COMMAND ${CMAKE_COMMAND}
+                  --build
+                  <BINARY_DIR>
+                  ${PARALLEL}
+    TEST_COMMAND ""
+    LOG_DOWNLOAD OFF
+    LOG_CONFIGURE OFF
+    LOG_BUILD OFF
+    LOG_INSTALL OFF)
+
+# This makes it easy to compile (or install) the dependencies before the
+# project.
+add_custom_target(project-dependencies)
+add_dependencies(project-dependencies ${GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST})

--- a/gcs-indexer/super/external/boost.cmake
+++ b/gcs-indexer/super/external/boost.cmake
@@ -1,0 +1,44 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+
+if (NOT TARGET boost-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_BOOST_URL
+            "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_BOOST_SHA256
+            "96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+            boost-project
+            EXCLUDE_FROM_ALL ON
+            PREFIX "${CMAKE_BINARY_DIR}/external/boost"
+            INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+            URL ${GOOGLE_CLOUD_CPP_BOOST_URL}
+            URL_HASH SHA256=${GOOGLE_CLOUD_CPP_BOOST_SHA256}
+            LIST_SEPARATOR |
+            CONFIGURE_COMMAND ./bootstrap.sh --prefix=<INSTALL_DIR>
+            BUILD_COMMAND ./b2 install
+            BUILD_IN_SOURCE ON
+            INSTALL_COMMAND ""
+            LOG_DOWNLOAD ON
+            LOG_CONFIGURE OFF
+            LOG_BUILD OFF
+            LOG_INSTALL OFF)
+endif ()

--- a/gcs-indexer/super/external/c-ares.cmake
+++ b/gcs-indexer/super/external/c-ares.cmake
@@ -1,0 +1,48 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+
+if (NOT TARGET c-ares-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_C_ARES_URL
+        "https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_C_ARES_SHA256
+        "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        c-ares-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/crc32c.cmake
+++ b/gcs-indexer/super/external/crc32c.cmake
@@ -1,0 +1,54 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+
+if (NOT TARGET crc32c-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_CRC32C_URL
+        "https://github.com/google/crc32c/archive/1.1.0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_CRC32C_SHA256
+        "49de137bf1c2eb6268d5122674f7dd1524b9148ba65c7b85c5ae4b9be104a25a")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        crc32c-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCRC32C_BUILD_TESTS=OFF
+                   -DCRC32C_BUILD_BENCHMARKS=OFF
+                   -DCRC32C_USE_GLOG=OFF
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/curl.cmake
+++ b/gcs-indexer/super/external/curl.cmake
@@ -1,0 +1,21 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+include(external/c-ares)
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(CURL REQUIRED)

--- a/gcs-indexer/super/external/external-project-helpers.cmake
+++ b/gcs-indexer/super/external/external-project-helpers.cmake
@@ -1,0 +1,68 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(GNUInstallDirs)
+
+function (set_external_project_build_parallel_level var_name)
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        if (DEFINED ENV{NCPU})
+            set(${var_name} "--" "-j" "$ENV{NCPU}" PARENT_SCOPE)
+        else()
+            include(ProcessorCount)
+            processorcount(NCPU)
+            set(${var_name} "--" "-j" "${NCPU}" PARENT_SCOPE)
+        endif ()
+    else()
+        set(${var_name} "" PARENT_SCOPE)
+    endif ()
+endfunction ()
+
+set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX "${CMAKE_BINARY_DIR}/local"
+    CACHE STRING "Configure where are the external projects installed.")
+mark_as_advanced(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX)
+
+function (google_cloud_cpp_set_prefix_vars)
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH
+            "${CMAKE_PREFIX_PATH}"
+            "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+            "<INSTALL_DIR>")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_PREFIX_PATH
+                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+
+    # Depending on the platform libraries get installed in `lib` or `lib64`
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${GOOGLE_CLOUD_CPP_PREFIX_PATH}"
+        PARENT_SCOPE)
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}"
+        PARENT_SCOPE)
+endfunction ()

--- a/gcs-indexer/super/external/google-cloud-cpp-common.cmake
+++ b/gcs-indexer/super/external/google-cloud-cpp-common.cmake
@@ -1,0 +1,59 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+include(external/grpc)
+include(external/googleapis)
+include(external/googletest)
+
+if (NOT TARGET google-cloud-cpp-common-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_URL
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.17.0.tar.gz"
+    )
+    set(GOOGLE_CLOUD_CPP_SHA256
+        "997ba70404c4cc01bc2753efa43fb225045a81fe2338331ae52325926c80fadc")
+
+    set_external_project_build_parallel_level(PARALLEL)
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        google-cloud-cpp-common-project
+        DEPENDS googleapis-project googletest-project grpc-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp-common"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SHA256}
+        LIST_SEPARATOR |
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DBUILD_TESTING=OFF
+            -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/google-cloud-cpp-spanner.cmake
+++ b/gcs-indexer/super/external/google-cloud-cpp-spanner.cmake
@@ -1,0 +1,53 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+include(external/google-cloud-cpp-common)
+include(external/googleapis)
+
+if (NOT TARGET google-cloud-cpp-spanner-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(
+        GOOGLE_CLOUD_CPP_SPANNER_URL
+        "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.5.0.tar.gz"
+        )
+    set(GOOGLE_CLOUD_CPP_SPANNER_SHA256
+        "06673c29657adeb4346b5c08b44739c2455bbc39a8be39c1ca9457ae5ec5f1cc")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        google-cloud-cpp-spanner-project
+        DEPENDS googleapis-project google-cloud-cpp-common-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp-spanner"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_SPANNER_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SPANNER_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DBUILD_TESTING=OFF
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE OFF
+        LOG_BUILD OFF
+        LOG_INSTALL OFF)
+endif ()

--- a/gcs-indexer/super/external/google-cloud-cpp.cmake
+++ b/gcs-indexer/super/external/google-cloud-cpp.cmake
@@ -1,0 +1,55 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+include(external/curl)
+include(external/crc32c)
+include(external/grpc)
+include(external/googleapis)
+find_package(CURL REQUIRED)
+
+if (NOT TARGET google-cloud-cpp-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_URL
+        "https://github.com/googleapis/google-cloud-cpp/archive/v0.17.0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_SHA256
+        "d67fed328d82aa404c3ab8f52814914f419a673573e3bbd98b4e6c405ca3cd06")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        google-cloud-cpp-project
+        DEPENDS googleapis-project grpc-project crc32c-project google-cloud-cpp-common-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DBUILD_TESTING=OFF
+                   -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE OFF
+        LOG_BUILD OFF
+        LOG_INSTALL OFF)
+endif ()

--- a/gcs-indexer/super/external/googleapis.cmake
+++ b/gcs-indexer/super/external/googleapis.cmake
@@ -1,0 +1,59 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+find_package(Threads REQUIRED)
+include(external/grpc)
+
+if (NOT TARGET googleapis-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
+        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz")
+    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
+        "f1443a10c545114b19fe9dc352568cb03b588813b12cc5db8780b64ae9a09ce1")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        googleapis-project
+        DEPENDS grpc-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
+        LIST_SEPARATOR |
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/googletest.cmake
+++ b/gcs-indexer/super/external/googletest.cmake
@@ -1,0 +1,53 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+
+if (NOT TARGET googletest-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(
+        GOOGLE_CLOUD_CPP_GOOGLETEST_URL
+        "https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.tar.gz"
+        )
+    set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
+        "8d9aa381a6885fe480b7d0ce8ef747a0b8c6ee92f99d74ab07e3503434007cb0")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        googletest-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_GOOGLETEST_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/grpc.cmake
+++ b/gcs-indexer/super/external/grpc.cmake
@@ -1,0 +1,60 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+include(external/protobuf)
+include(external/c-ares)
+find_package(OpenSSL REQUIRED)
+
+if (NOT TARGET grpc-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_GRPC_URL
+        "https://github.com/grpc/grpc/archive/v1.23.0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_GRPC_SHA256
+        "f56ced18740895b943418fa29575a65cc2396ccfa3159fa40d318ef5f59471f9")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        grpc-project
+        DEPENDS protobuf-project c-ares-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DgRPC_BUILD_TESTS=OFF
+                   -DgRPC_ZLIB_PROVIDER=package
+                   -DgRPC_SSL_PROVIDER=package
+                   -DgRPC_CARES_PROVIDER=package
+                   -DgRPC_PROTOBUF_PROVIDER=package
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/gcs-indexer/super/external/protobuf.cmake
+++ b/gcs-indexer/super/external/protobuf.cmake
@@ -1,0 +1,66 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/external-project-helpers)
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
+
+if (NOT TARGET protobuf-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
+        "https://github.com/google/protobuf/archive/v3.9.1.tar.gz")
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
+        "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357")
+
+    google_cloud_cpp_set_prefix_vars()
+    externalproject_add(
+        protobuf-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_PROTOBUF_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_PROTOBUF_SHA256}
+        LIST_SEPARATOR |
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            -DCMAKE_BUILD_TYPE=Debug
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            # Protobuf installs using `CMAKE_INSTALL_LIBDIR`, as it should,
+            # which expands to `lib` or `lib64`. But hard-codes RPATH to
+            # `$ORIGIN/../lib`, so change the default `LIBDIR` to something
+            # that works.
+            # https://github.com/protocolbuffers/protobuf/pull/6204
+            -DCMAKE_INSTALL_LIBDIR=lib
+            -Dprotobuf_BUILD_TESTS=OFF
+            -Dprotobuf_DEBUG_POSTFIX=
+            -H<SOURCE_DIR>/cmake
+            -B<BINARY_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()


### PR DESCRIPTION
In this PR we introduce a new example that can index GCS metadata (the
names and properties of all the objects in a Bucket) using Cloud
Spanner. One of the programs in this example can be deployed to Cloud
Run to maintain the index as objects are modified, removed, or uploaded
to GCS. There are also examples showing how to run the program to index
a bucket on Google Kubernetes Engine (GKE).

The example uses the (existing) C++ client libraries for Google Cloud,
and showcases how to deploy C++ applications to GCP.