### PR TITLE
Update README.md

### DIFF
--- a/speech/api/README.md
+++ b/speech/api/README.md
@@ -73,6 +73,6 @@ These samples will only build and run on **Linux**.
 
 1.  **Run the tests:**
     ```sh
-    cd cpp-docs-sample/speech/api
+    cd cpp-docs-samples/speech/api
     make run_tests
     ```


### PR DESCRIPTION
The cloned folder is named cpp-docs-samples. The cd command doesn't work since it's missing the "s" at the end of samples.