### PR TITLE
cleanup: fix c++ formatting

### DIFF
--- a/gcs-indexer/refresh_index_for_bucket.cc
+++ b/gcs-indexer/refresh_index_for_bucket.cc
@@ -96,15 +96,11 @@ class bounded_queue {
  private:
   [[nodiscard]] bool empty() const { return buffer_.empty(); }
 
-      [[nodiscard]] bool below_hwm() const {
-    return buffer_.size() <= hwm_;
-  }
+  [[nodiscard]] bool below_hwm() const { return buffer_.size() <= hwm_; }
 
   [[nodiscard]] bool below_lwm() const { return buffer_.size() <= lwm_; }
 
-      [[nodiscard]] bool has_readers() const {
-    return reader_count_ > 0;
-  }
+  [[nodiscard]] bool has_readers() const { return reader_count_ > 0; }
 
   [[nodiscard]] bool has_writers() const { return writer_count_ > 0; }
 


### PR DESCRIPTION
Now that the GitHub action is actually running, it caught one file
formatted incorrectly.