### PR TITLE
ci: initial build scripts for Cloud Build

### DIFF
--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -1,0 +1,83 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+options:
+  machineType: 'N1_HIGHCPU_32'
+  diskSizeGb: '512'
+
+steps:
+  # Create a container will all the development tools
+  - name: 'gcr.io/kaniko-project/executor:edge'
+    args: [
+        "--context=dir:///workspace/",
+        "--dockerfile=ci/devtools.Dockerfile",
+        "--cache=true",
+        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/ci/cache",
+        "--destination=gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}",
+    ]
+    timeout: 1800s
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['pull', 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}']
+
+  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
+    env:
+      'VCPKG_BINARY_SOURCES=x-gcs,${_VCPKG_BUCKET_PREFIX},readwrite'
+    volumes:
+      name: fcs-fast-transfers-build
+      path: '/b'
+    args: [
+      'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
+      '-S', '/workspace/gcs-fast-transfers', '-B', '/b'
+    ]
+
+  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
+    env:
+      'VCPKG_BINARY_SOURCES=x-gcs,${_VCPKG_BUCKET_PREFIX},readwrite'
+    volumes:
+      name: fcs-fast-transfers-build
+      path: '/b'
+    args: ['cmake', '--build', '/b']
+
+  # Remove the images created by this build.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set +e
+        gcloud container images delete -q gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}
+        exit 0
+
+  # The previous step may not run if the build fails. Garbage collect any
+  # images created by this script more than 4 weeks ago. This step should
+  # not break the build on error, and it can start running as soon as the
+  # build does.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    waitFor: ['-']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set +e
+        for image in cpp-samples/ci/devtools; do
+          gcloud --project=${PROJECT_ID} container images list-tags gcr.io/${PROJECT_ID}/$${image} \
+              --format='get(digest)' --filter='timestamp.datetime < -P4W' | \
+          xargs printf "gcr.io/${PROJECT_ID}/$${image}@$$1\n"
+        done | \
+        xargs -P 4 -L 32 gcloud container images delete -q --force-delete-tags
+        exit 0
+
+substitutions:
+  _VCPKG_BUCKET_PREFIX: "gs://cloud-cpp-testing-resources-vcpkg-cache/cpp-samples"

--- a/ci/devtools.Dockerfile
+++ b/ci/devtools.Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update \
+    && apt install -y build-essential git gcc g++ clang llvm cmake ninja-build pkg-config python3 tar zip unzip curl
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
+    && apt-get update -y \
+    && apt-get install google-cloud-sdk -y
+
+WORKDIR /usr/local/vcpkg
+RUN curl -sSL "https://github.com/microsoft/vcpkg/archive/9b9a6680b25872989c8eb0303d670f32e5cfe6a4.tar.gz" | \
+    tar --strip-components=1 -zxf - \
+    && ./bootstrap-vcpkg.sh
+


### PR DESCRIPTION
This will let us run builds in Cloud Build, which then can run
integration tests.