### PR TITLE
ci: make Cloud Build scripts runnable from triggers

### DIFF
--- a/cloud-run-hello-world/cloudbuild.yaml
+++ b/cloud-run-hello-world/cloudbuild.yaml
@@ -16,12 +16,16 @@ timeout: 1800s
 options:
   machineType: 'N1_HIGHCPU_8'
   diskSizeGb: '512'
+substitutions:
+  _CONTEXT: 'dir:///workspace/'
 
 steps:
   # Create a container, use Kaniko to cache the temporary results.
   - name: 'gcr.io/kaniko-project/executor:edge'
     args: [
-        "--context=dir:///workspace/",
+        # Using a substitution here allows us to call this script from
+        # the top-level directory, as Cloud Build does.
+        "--context=${_CONTEXT}",
         "--dockerfile=Dockerfile",
         "--cache=true",
         "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/ci/cache",

--- a/gcs-indexer/Dockerfile
+++ b/gcs-indexer/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/5dc53211caedebf4387d590155ed53ee44161f10.tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/9b9a6680b25872989c8eb0303d670f32e5cfe6a4.tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to
@@ -65,8 +65,7 @@ WORKDIR /v/source
 
 # Run the CMake configuration step, setting the options to use vcpkg.
 RUN cmake -S/v/source -B/v/binary -GNinja \
-    -DCMAKE_TOOLCHAIN_FILE=/var/tmp/build/vcpkg/scripts/buildsystems/vcpkg.cmake || \
-    cat /v/binary/vcpkg-manifest-install.log
+    -DCMAKE_TOOLCHAIN_FILE=/var/tmp/build/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 RUN cmake --build /v/binary
 RUN strip /v/binary/pubsub_handler

--- a/gcs-indexer/cloudbuild.yaml
+++ b/gcs-indexer/cloudbuild.yaml
@@ -13,23 +13,32 @@
 # limitations under the License.
 
 timeout: 3600s
+options:
+  machineType: 'N1_HIGHCPU_32'
+  diskSizeGb: '512'
+substitutions:
+  _CONTEXT: 'dir:///workspace/'
+
 steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args: [
+        # Using a substitution here allows us to call this script from
+        # the top-level directory, as Cloud Build does.
+        "--context=${_CONTEXT}",
+        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/ci/cache",
         "--destination=gcr.io/${PROJECT_ID}/cpp-samples/gcs-indexer/pubsub-handler:${SHORT_SHA}",
-        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/cache",
         "--target=pubsub-handler",
         "--cache=true"
     ]
     timeout: 3600s
   - name: 'gcr.io/kaniko-project/executor:latest'
     args: [
+        # Using a substitution here allows us to call this script from
+        # the top-level directory, as Cloud Build does.
+        "--context=${_CONTEXT}",
+        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/ci/cache",
         "--destination=gcr.io/${PROJECT_ID}/cpp-samples/gcs-indexer/tools:${SHORT_SHA}",
-        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/cache",
         "--target=tools",
         "--cache=true"
     ]
     timeout: 3600s
-
-options:
-  machineType: 'N1_HIGHCPU_32'

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/09f0dc0a79f8075606f83b61492e814511b54d9f.tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/9b9a6680b25872989c8eb0303d670f32e5cfe6a4.tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to

--- a/populate-bucket/cloudbuild.yaml
+++ b/populate-bucket/cloudbuild.yaml
@@ -13,14 +13,21 @@
 # limitations under the License.
 
 timeout: 3600s
+options:
+  machineType: 'N1_HIGHCPU_32'
+  diskSizeGb: '512'
+substitutions:
+  _CONTEXT: 'dir:///workspace/'
+
 steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args: [
+        # Using a substitution here allows us to call this script from
+        # the top-level directory, as Cloud Build does.
+        "--context=${_CONTEXT}",
+        "--cache-repo=gcr.io/${PROJECT_ID}/cpp-samples/ci/cache",
         "--destination=gcr.io/${PROJECT_ID}/cpp-samples/populate-bucket:${SHORT_SHA}",
         "--cache=true",
         "--cache-ttl=48h"
     ]
     timeout: 3600s
-
-options:
-  machineType: 'N1_HIGHCPU_32'


### PR DESCRIPTION
Cloud Build triggers (that is, automatically started builds created by
pull requests or merges) always run at the top-level directory. To
validate these YAML scripts we want to run them automatically, that
requires some configurability so they can run either from the top-level
directory or from the directory that contains them.

This is a bit experimental, I *believe* it will work, but I need to merge
before I can test the idea.
