### PR TITLE
ci: avoid timeouts in gcs-indexer

### DIFF
--- a/gcs-indexer/cloudbuild.yaml
+++ b/gcs-indexer/cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 3600s
+timeout: 7200s
 options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'


### PR DESCRIPTION
This seems to timeout with a cold cache, which requires re-starting the
PR build manually. Setting to a higher value to avoid the timeouts.