### PR TITLE
cleanup: skip eventarc using Pub/Sub

### DIFF
--- a/getting-started/gcs_indexing.cc
+++ b/getting-started/gcs_indexing.cc
@@ -22,6 +22,7 @@
 
 namespace google::cloud::cpp_samples {
 
+namespace gcf = ::google::cloud::functions;
 namespace gcs = ::google::cloud::storage;
 namespace spanner = ::google::cloud::spanner;
 
@@ -29,8 +30,11 @@ nlohmann::json LogFormat(std::string const& sev, std::string const& msg) {
   return nlohmann::json{{"severity", sev}, {"message", msg}}.dump();
 }
 
-void LogError(std::string const& msg) {
+gcf::HttpResponse LogError(std::string const& msg) {
   std::cerr << LogFormat("error", msg) << "\n";
+  return gcf::HttpResponse{}
+      .set_result(gcf::HttpResponse::kBadRequest)
+      .set_payload(msg);
 }
 
 using GetField = std::function<spanner::Value(gcs::ObjectMetadata const&)>;

--- a/getting-started/gcs_indexing.h
+++ b/getting-started/gcs_indexing.h
@@ -15,6 +15,7 @@
 #ifndef CPP_SAMPLES_GETTING_STARTED_GCS_INDEXING_H
 #define CPP_SAMPLES_GETTING_STARTED_GCS_INDEXING_H
 
+#include <google/cloud/functions/http_response.h>
 #include <google/cloud/spanner/mutations.h>
 #include <google/cloud/storage/object_metadata.h>
 #include <string>
@@ -22,7 +23,7 @@
 
 namespace google::cloud::cpp_samples {
 
-void LogError(std::string const& msg);
+google::cloud::functions::HttpResponse LogError(std::string const& msg);
 
 google::cloud::spanner::Mutation UpdateObjectMetadata(
     google::cloud::storage::ObjectMetadata const& object);


### PR DESCRIPTION
Tolerate higher latency by sending messages via a push
subscription in Cloud Pub/Sub. It also avoids introducing more
infrastructure.
