### PR TITLE
ci: use release version of kaniko

### DIFF
--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -21,7 +21,7 @@ substitutions:
 
 steps:
   # Create a container will all the development tools
-  - name: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
+  - name: 'gcr.io/kaniko-project/executor:v1.8.1'
     args: [
         "--context=dir:///workspace/",
         "--dockerfile=ci/devtools.Dockerfile",

--- a/cloud-run-hello-world/cloudbuild.yaml
+++ b/cloud-run-hello-world/cloudbuild.yaml
@@ -21,7 +21,7 @@ substitutions:
 
 steps:
   # Create a container, use Kaniko to cache the temporary results.
-  - name: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
+  - name: 'gcr.io/kaniko-project/executor:v1.8.1'
     args: [
         # Using a substitution here allows us to call this script from
         # the top-level directory, as Cloud Build does.

--- a/getting-started/gke/cloudbuild.yaml
+++ b/getting-started/gke/cloudbuild.yaml
@@ -20,7 +20,7 @@ substitutions:
   _CONTEXT: 'dir:///workspace/'
 
 steps:
-  - name: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
+  - name: 'gcr.io/kaniko-project/executor:v1.8.1'
     args: [
         # Using a substitution here allows us to call this script from
         # the top-level directory, as Cloud Build does.

--- a/populate-bucket/cloudbuild.yaml
+++ b/populate-bucket/cloudbuild.yaml
@@ -20,7 +20,7 @@ substitutions:
   _CONTEXT: 'dir:///workspace/'
 
 steps:
-  - name: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
+  - name: 'gcr.io/kaniko-project/executor:v1.8.1'
     args: [
         # Using a substitution here allows us to call this script from
         # the top-level directory, as Cloud Build does.


### PR DESCRIPTION
Kaniko used to crash with the release version circa v1.6.0, we have
moved to v1.8.1, and in other repositories we have no problems with the
release version.