### PR TITLE
chore: enable renovate-bot for Dockerfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,17 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:weekdays"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        ".*Dockerfile$"
+      ],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>.*?)/archive/(?<currentValue>.*?)\\.tar\\.gz"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }


### PR DESCRIPTION
Inspired by the configuration in `google-cloud-cpp`.  I expect it will
automatically update packages installed from GitHub.  At the moment,
only `vcpkg` seems to be installed this way.