### PR TITLE
chore: more renovatebot configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,8 @@
       "matchStrings": [
         "https://github\\.com/(?<depName>.*?)/archive/(?<currentValue>.*?)\\.tar\\.gz"
       ],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose"
     }
   ]
 }


### PR DESCRIPTION
Another iteration configuring renovatebot.  The dashboard says
(I think) that the `vcpkg` versions do not follow semver (which
they don't).  Try something less strict.

If curious, the errors I am looking at are here:

https://app.renovatebot.com/dashboard#github/GoogleCloudPlatform/cpp-samples/662800511

