### PR TITLE
fix: use `std::ios::binary` to open files

### DIFF
--- a/gcs-fast-transfers/gcs_fast_transfers.cc
+++ b/gcs-fast-transfers/gcs_fast_transfers.cc
@@ -38,7 +38,7 @@ std::string format_size(std::int64_t size) {
 }
 
 std::pair<std::int64_t, std::string> file_info(std::string const& filename) {
-  std::ifstream is(filename);
+  std::ifstream is(filename, std::ios::binary);
   std::vector<char> buffer(1024 * 1024L);
   std::uint32_t crc32c = 0;
   std::int64_t size = 0;

--- a/speech/api/streaming_transcribe.cc
+++ b/speech/api/streaming_transcribe.cc
@@ -36,10 +36,10 @@ static const char kUsage[] =
 static void MicrophoneThreadMain(
     grpc::ClientReaderWriterInterface<StreamingRecognizeRequest,
                                       StreamingRecognizeResponse>* streamer,
-    char* file_path) {
+    std::string const& file_path) {
   StreamingRecognizeRequest request;
-  std::ifstream file_stream(file_path);
-  const size_t chunk_size = 64 * 1024;
+  std::ifstream file_stream(file_path, std::ios::binary);
+  auto const chunk_size = 64 * 1024;
   std::vector<char> chunk(chunk_size);
   while (true) {
     // Read another chunk from the file.

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
   // Get ready to write audio content.  Open the file, allocate a chunk, and
   // start a timer.  Use the timer to simulate a microphone, where the audio
   // content is arriving in one chunk per second.
-  std::ifstream file_stream(file_path);
+  std::ifstream file_stream(file_path, std::ios::binary);
   const size_t chunk_size = 64 * 1024;
   std::vector<char> chunk(chunk_size);
   std::chrono::system_clock::time_point next_write_time_point =

--- a/speech/api/transcribe.cc
+++ b/speech/api/transcribe.cc
@@ -54,8 +54,9 @@ int main(int argc, char** argv) {
     // [START speech_sync_recognize]
     // Load the audio file from disk into the request.
     request.mutable_audio()->mutable_content()->assign(
-        std::istreambuf_iterator<char>(std::ifstream(file_path).rdbuf()),
-        std::istreambuf_iterator<char>());
+        std::istreambuf_iterator<char>(
+            std::ifstream(file_path, std::ios::binary).rdbuf()),
+        {});
     // [END speech_sync_recognize]
   }
   // [START speech_sync_recognize]


### PR DESCRIPTION
These files may be (and often are) binary files, and on Windows one
must use `std::ios::binary` or bad things happen.

Motivated by #187 and possibly other things.
