### PR TITLE
fix: get the speech/ example working on Windows

### DIFF
--- a/speech/api/.gitignore
+++ b/speech/api/.gitignore
@@ -1,5 +1,1 @@
-# The binaries.
-transcribe
-async_transcribe
-streaming_transcribe
-streaming_transcribe_singlethread
+cmake-out/

--- a/speech/api/CMakeLists.txt
+++ b/speech/api/CMakeLists.txt
@@ -21,21 +21,25 @@ set(PACKAGE_BUGREPORT
     "https://github.com/GoogleCloudPlatform/cpp-samples/issues")
 project(cpp-samples-speech-api CXX)
 
-# Configure the Compiler options, we will be using C++11 features.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-find_package(google_cloud_cpp_googleapis REQUIRED)
+find_package(google_cloud_cpp_speech REQUIRED)
+find_package(Boost 1.66 REQUIRED COMPONENTS program_options)
 find_package(Threads)
 
 add_library(parse_arguments STATIC parse_arguments.cc parse_arguments.h)
-target_link_libraries(parse_arguments
-                      PUBLIC google-cloud-cpp::cloud_speech_protos)
+target_compile_features(parse_arguments PUBLIC cxx_std_11)
+target_link_libraries(
+  parse_arguments PUBLIC Boost::program_options
+                         google-cloud-cpp::cloud_speech_protos)
+if(MSVC)
+  # The protobuf-generated files have warnings under the default MSVC settings.
+  # We are not interested in these warnings, because we cannot fix them.
+  target_compile_options(parse_arguments PUBLIC "/wd4244" "/wd4251")
+endif()
 
 foreach(target async_transcribe streaming_transcribe
                streaming_transcribe_singlethread transcribe)
   add_executable("${target}" "${target}.cc")
   target_link_libraries(
     "${target}" PRIVATE parse_arguments google-cloud-cpp::cloud_speech_protos
-                        Threads::Threads)
+                        Boost::program_options Threads::Threads)
 endforeach()

--- a/speech/api/async_transcribe.cc
+++ b/speech/api/async_transcribe.cc
@@ -83,7 +83,7 @@ int main(int argc, char** argv) try {
   LongRunningRecognizeResponse response;
   op.response().UnpackTo(&response);
   // Dump the transcript of all the results.
-  for (auto const & result : response.results()) {
+  for (auto const& result : response.results()) {
     for (auto const& alternative : result.alternatives()) {
       std::cout << alternative.confidence() << "\t" << alternative.transcript()
                 << "\n";
@@ -91,8 +91,8 @@ int main(int argc, char** argv) try {
   }
   // [END speech_async_recognize_gcs]
   return 0;
-} catch(std::exception const& ex) {
+} catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception thrown: " << ex.what() << "\n"
-  << kUsage << "\n";
+            << kUsage << "\n";
   return 1;
 }

--- a/speech/api/parse_arguments.cc
+++ b/speech/api/parse_arguments.cc
@@ -45,13 +45,13 @@ ParseResult ParseArguments(int argc, char* argv[]) {
             vm);
   po::notify(vm);
 
-  // Validate the arguments.
-  if (vm.count("path") == 0)
-    throw std::runtime_error("Missing audio filename in the command line");
   auto const path = vm["path"].as<std::string>();
   auto const bitrate = vm["bitrate"].as<int>();
   auto const language_code = vm["language-code"].as<std::string>();
   // Validate the command-line options.
+  if (path.empty()) {
+    throw std::runtime_error("The audio file path cannot be empty");
+  }
   if (bitrate < 0) {
     throw std::runtime_error(
         "--bitrate option must be a positive number, value=" +

--- a/speech/api/parse_arguments.h
+++ b/speech/api/parse_arguments.h
@@ -20,7 +20,11 @@
 // Parse the command line arguments, and set the config options accordingly.
 // Returns:
 //   The audio file path, or nullptr if an error occurred.
-char* ParseArguments(int argc, char** argv,
-                     google::cloud::speech::v1::RecognitionConfig* config);
+struct ParseResult {
+    google::cloud::speech::v1::RecognitionConfig config;
+    std::string path;
+};
+
+ParseResult ParseArguments(int argc, char* argv[]);
 
 #endif  // CPP_SAMPLES_SPEECH_API_PARSE_ARGUMENTS_H

--- a/speech/api/parse_arguments.h
+++ b/speech/api/parse_arguments.h
@@ -21,8 +21,8 @@
 // Returns:
 //   The audio file path, or nullptr if an error occurred.
 struct ParseResult {
-    google::cloud::speech::v1::RecognitionConfig config;
-    std::string path;
+  google::cloud::speech::v1::RecognitionConfig config;
+  std::string path;
 };
 
 ParseResult ParseArguments(int argc, char* argv[]);

--- a/speech/api/vcpkg.json
+++ b/speech/api/vcpkg.json
@@ -1,10 +1,14 @@
 {
   "name": "gcp-cpp-samples-speech-api",
-  "version-string": "0.0.1-dev",
-  "port-version": 1,
+  "version-string": "unversioned",
   "homepage": "https://github.com/GoogleCloudPlatform/cpp-samples/",
   "description": "Examples using the Text-to-Speech API",
   "dependencies": [
-    "google-cloud-cpp"
+    {
+      "name": "google-cloud-cpp",
+      "default-features": false,
+      "features": ["speech"]
+    },
+    "boost-program-options"
   ]
 }


### PR DESCRIPTION
I think the specific problem that made this example fail affected all
platforms, namely, that it read 0 bytes from a file (this can happen at
EOF if the file is a multiple of the read buffer size), and then tried
to send this 0-byte blob to the service.

To get the code working on Windows I had to replace `getopt(1)` with
something more portable, I chose Boost::program_options because we use
it in other places.

I also made a pass making the code look more idiomatic for C++11: prefer
using range-based for loops, prefer returning values, use exceptions
(instead of `nullptr`) to signal errors, etc.

We should make a second pass fixing this code to use the C++ client
library, calling gRPC directly is exceedingly painful.

Fixes #187 