### PR TITLE
cleanup(speech): use client library for async streaming

### DIFF
--- a/speech/api/CMakeLists.txt
+++ b/speech/api/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(Boost 1.66 REQUIRED COMPONENTS program_options)
 find_package(Threads)
 
 add_library(parse_arguments STATIC parse_arguments.cc parse_arguments.h)
-target_compile_features(parse_arguments PUBLIC cxx_std_11)
+target_compile_features(parse_arguments PUBLIC cxx_std_14)
 target_link_libraries(
   parse_arguments PUBLIC Boost::program_options
                          google-cloud-cpp::cloud_speech_protos)

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace g = ::google::cloud;

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -13,158 +13,164 @@
 // limitations under the License.
 
 #include "parse_arguments.h"
-#include <google/cloud/speech/v1/cloud_speech.grpc.pb.h>
-#include <grpcpp/grpcpp.h>
+#include <google/cloud/completion_queue.h>
+#include <google/cloud/grpc_options.h>
+#include <google/cloud/speech/speech_client.h>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
-using google::cloud::speech::v1::Speech;
-using google::cloud::speech::v1::StreamingRecognizeRequest;
-using google::cloud::speech::v1::StreamingRecognizeResponse;
+namespace g = ::google::cloud;
+namespace speech = ::google::cloud::speech;
+using RecognizeStream = ::google::cloud::AsyncStreamingReadWriteRpc<
+    speech::v1::StreamingRecognizeRequest,
+    speech::v1::StreamingRecognizeResponse>;
 
-static const char kUsage[] =
-    "Usage:\n"
-    "   streaming_transcribe_singlethread "
-    "[--bitrate N] audio.(raw|ulaw|flac|amr|awb)\n";
+auto constexpr kUsage = R"""(Usage:
+  streaming_transcribe_singlethread [--bitrate N] audio.(raw|ulaw|flac|amr|awb)
+)""";
+
+class Handler : public std::enable_shared_from_this<Handler> {
+ public:
+  static std::shared_ptr<Handler> Create(google::cloud::CompletionQueue cq,
+                                         ParseResult args) {
+    return std::shared_ptr<Handler>(
+        new Handler(std::move(cq), std::move(args)));
+  }
+
+  g::future<g::Status> Start(speech::SpeechClient& client) {
+    // Get ready to write audio content.  Create the stream, and start it.
+    stream_ = client.AsyncStreamingRecognize(google::cloud::ExperimentalTag{});
+    // The stream can fail to start, .get() returns an error in this case.
+    if (!stream_->Start().get()) return StartFailure();
+    // Write the first request, containing the config only.
+    if (!stream_->Write(request_, grpc::WriteOptions{}).get()) {
+      // Write().get() returns false if the stream is closed.
+      return StartFailure();
+    }
+    auto self = shared_from_this();
+    // This creates a series of reads, when each read completes successfully a
+    // new one starts.
+    stream_->Read().then([self](auto f) { self->OnRead(f.get()); });
+    // This creates a series of timer -> write -> timer -> ... steps.
+    cq_.MakeRelativeTimer(std::chrono::seconds(1)).then([self](auto f) {
+      self->OnTimer(f.get().status());
+    });
+    return done_.get_future();
+  }
+
+ private:
+  Handler(google::cloud::CompletionQueue cq, ParseResult args)
+      : cq_(std::move(cq)), file_(args.path, std::ios::binary) {
+    auto& streaming_config = *request_.mutable_streaming_config();
+    *streaming_config.mutable_config() = std::move(args.config);
+  }
+
+  g::future<g::Status> StartFailure() {
+    auto self = shared_from_this();
+    writing_ = false;
+    reading_ = false;
+    stream_->Finish().then([self](auto f) { self->OnFinish(f.get()); });
+    return done_.get_future();
+  }
+
+  void OnFinish(g::Status s) { done_.set_value(s); }
+
+  void OnTimer(g::Status s) {
+    // On a timer error the completion queue is not usable
+    // just return.
+    if (!s.ok()) return;
+    // If the file is not usable, close the stream
+    auto self = shared_from_this();
+    auto constexpr kChunkSize = 64 * 1024;
+    std::vector<char> chunk(kChunkSize);
+    file_.read(chunk.data(), chunk.size());
+    auto const bytes_read = file_.gcount();
+    if (bytes_read > 0) {
+      request_.clear_streaming_config();
+      request_.set_audio_content(chunk.data(), bytes_read);
+      std::cout << "Sending " << bytes_read / 1024 << "k bytes." << std::endl;
+      stream_->Write(request_, grpc::WriteOptions()).then([self](auto f) {
+        self->OnWrite(f.get());
+      });
+    }
+  }
+
+  void OnRead(absl::optional<speech::v1::StreamingRecognizeResponse> response) {
+    if (!response.has_value()) return CloseReadSide();
+    // Dump the transcript of all the results.
+    for (auto const& result : response->results()) {
+      std::cout << "Result stability: " << result.stability() << "\n";
+      for (auto const& alternative : result.alternatives()) {
+        std::cout << alternative.confidence() << "\t"
+                  << alternative.transcript() << "\n";
+      }
+    }
+    auto self = shared_from_this();
+    stream_->Read().then([self](auto f) { self->OnRead(f.get()); });
+  }
+
+  void OnWrite(bool ok) {
+    auto self = shared_from_this();
+    if (!ok) return CloseWriteSide();
+    if (!file_) {
+      stream_->WritesDone().then(
+          [self](auto f) { self->OnWritesDone(f.get()); });
+      return;
+    }
+    // Schedule a new timer to read more data
+    cq_.MakeRelativeTimer(std::chrono::seconds(1)).then([&](auto f) {
+      self->OnTimer(f.get().status());
+    });
+  }
+
+  void OnWritesDone(bool) { CloseWriteSide(); }
+
+  void CloseWriteSide() {
+    writing_ = false;
+    if (!reading_) return Close();
+  }
+
+  void CloseReadSide() {
+    reading_ = false;
+    if (!writing_) return Close();
+  }
+
+  void Close() {
+    auto self = shared_from_this();
+    stream_->Finish().then([self](auto f) { self->OnFinish(f.get()); });
+  }
+
+  google::cloud::CompletionQueue cq_;
+  speech::v1::StreamingRecognizeRequest request_;
+  std::unique_ptr<RecognizeStream> stream_;
+  std::ifstream file_;
+  bool writing_ = true;
+  bool reading_ = true;
+  g::promise<g::Status> done_;
+};
 
 int main(int argc, char** argv) try {
-  // Create a Speech Stub connected to the speech service.
-  auto creds = grpc::GoogleDefaultCredentials();
-  auto channel = grpc::CreateChannel("speech.googleapis.com", creds);
-  std::unique_ptr<Speech::Stub> speech(Speech::NewStub(channel));
-  // Parse command line arguments.
-  auto args = ParseArguments(argc, argv);
+  // Create a CompletionQueue to demux the I/O and other asynchronous
+  // operations, and dedicate a thread to it.
+  g::CompletionQueue cq;
+  auto runner = std::thread{[](auto cq) { cq.Run(); }, cq};
 
-  StreamingRecognizeRequest request;
-  auto& streaming_config = *request.mutable_streaming_config();
-  *streaming_config.mutable_config() = args.config;
+  // Create a Speech client with the default configuration.
+  auto client = speech::SpeechClient(speech::MakeSpeechConnection(
+      g::Options{}.set<g::GrpcCompletionQueueOption>(cq)));
 
-  // Many things are happening at once:
-  // 1. Writing the initial request to the stream.
-  // 2. Writing chunks of audio content to the stream.
-  // 3. Reading responses from the stream.
-  // 4. Shutting down the stream.
-  // So, use a completion queue and tags to track them.
-  grpc::CompletionQueue cq;
-  struct Tag {
-    bool happening_now;  // Gets set to false when the operation completes.
-    const char* name;
-  };
-  Tag create_stream = {true, "create stream"};
-  Tag reading = {false, "reading"};
-  Tag writing = {false, "writing"};
-  Tag writes_done = {false, "writes done"};
-  Tag finishing = {false, "finishing"};
-  grpc::Status status;
-  bool server_closed_stream = false;
-  // Create the stream reader/writer.
-  grpc::ClientContext context;
-  auto streamer =
-      speech->AsyncStreamingRecognize(&context, &cq, &create_stream);
+  // Create a handler for the stream and run it until closed.
+  auto handler = Handler::Create(cq, ParseArguments(argc, argv));
+  auto status = handler->Start(client).get();
 
-  bool ok = false;
-  Tag* tag = nullptr;
-  // Block until the creation of the stream is done, we cannot start
-  // writing until that happens ...
-  if (!cq.Next(reinterpret_cast<void**>(&tag), &ok)) {
-    throw std::runtime_error(
-        "The completion queue unexpectedly shutdown or timedout.");
-  }
-  std::cout << tag->name << " completed." << std::endl;
-  tag->happening_now = false;
-  if (tag != &create_stream) {
-    throw std::runtime_error("Expected create_stream in cq.");
-  }
-  if (!ok) {
-    throw std::runtime_error("Stream closed while creating it.");
-  }
+  // Shutdown the completion queue
+  cq.Shutdown();
+  runner.join();
 
-  StreamingRecognizeResponse response;
-  // Write the first request, containing the config only.
-  streaming_config.set_interim_results(true);
-  writing.happening_now = true;
-  streamer->Write(request, &writing);
-  // Get ready to write audio content.  Open the file, allocate a chunk, and
-  // start a timer.  Use the timer to simulate a microphone, where the audio
-  // content is arriving in one chunk per second.
-  std::ifstream file_stream(args.path, std::ios::binary);
-  auto const chunk_size = 64 * 1024;
-  std::vector<char> chunk(chunk_size);
-  std::chrono::system_clock::time_point next_write_time_point =
-      std::chrono::system_clock::time_point::min();
-  bool writes_completed = false;
-  do {
-    if (!reading.happening_now && !finishing.happening_now) {
-      reading.happening_now = true;
-      // AsyncNext(), called below, will return the reading tag when the read
-      // completes.
-      streamer->Read(&response, &reading);
-    }
-    auto now = std::chrono::system_clock::now();
-    if (now >= next_write_time_point && !writing.happening_now) {
-      // Time to write another chunk of the file on the stream.
-      file_stream.read(chunk.data(), chunk.size());
-      auto const bytes_read = file_stream.gcount();
-      if (bytes_read > 0) {
-        request.clear_streaming_config();
-        request.set_audio_content(chunk.data(), bytes_read);
-        std::cout << "Sending " << bytes_read / 1024 << "k bytes." << std::endl;
-        writing.happening_now = true;
-        streamer->Write(request, &writing);
-      }
-      if (!file_stream) {
-        // Done writing.
-        writes_completed = true;
-        next_write_time_point =  // Never write again.
-            std::chrono::system_clock::time_point::max();
-      } else {
-        // Schedule the next write for one second from now.
-        next_write_time_point = now + std::chrono::duration<long>(1);
-      }
-    }
-    // Wait for a pending operation to complete.  Identify the operation that
-    // completed by examining tag.
-    switch (cq.AsyncNext(reinterpret_cast<void**>(&tag), &ok,
-                         next_write_time_point)) {
-      case grpc::CompletionQueue::SHUTDOWN:
-        throw std::runtime_error("The completion queue unexpectedly shutdown.");
-      case grpc::CompletionQueue::GOT_EVENT:
-        std::cout << tag->name << " completed." << std::endl;
-        tag->happening_now = false;
-        if (tag == &reading) {
-          // Dump the transcript of all the results.
-          for (auto const& result : response.results()) {
-            std::cout << "Result stability: " << result.stability() << "\n";
-            for (auto const& alternative : result.alternatives()) {
-              std::cout << alternative.confidence() << "\t"
-                        << alternative.transcript() << "\n";
-            }
-          }
-        }
-        if (tag == &writing && writes_completed) {
-          // After the last Write, send a WritesDone() ...
-          writes_done.happening_now = true;
-          // AsyncNext(), called above, will return the writes_done tag when
-          // the writes_done operation completes.
-          streamer->WritesDone(&writes_done);
-        }
-        if (!ok) {
-          server_closed_stream = true;
-          finishing.happening_now = true;
-          // AsyncNext() will return the finishing tag when the finishing
-          // operation completes.
-          streamer->Finish(&status, &finishing);
-        }
-        break;
-      case grpc::CompletionQueue::TIMEOUT:
-        break;  // Time to send another chunk of audio content.
-    }
-  } while (!server_closed_stream || finishing.happening_now);
   if (!status.ok()) {
-    // Report the RPC failure.
-    std::cerr << status.error_message() << std::endl;
+    std::cerr << "Error in transcribe stream: " << status << "\n";
     return 1;
   }
   return 0;

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -43,7 +43,7 @@ class Handler : public std::enable_shared_from_this<Handler> {
   g::future<g::Status> Start(speech::SpeechClient& client) {
     // Get ready to write audio content.  Create the stream, and start it.
     stream_ = client.AsyncStreamingRecognize(google::cloud::ExperimentalTag{});
-    // The stream can fail to start; `.get()` returns an `false` in this case.
+    // The stream can fail to start; `.get()` returns `false` in this case.
     if (!stream_->Start().get()) return StartFailure();
     // Write the first request, containing the config only.
     if (!stream_->Write(request_, grpc::WriteOptions{}).get()) {


### PR DESCRIPTION
I am less certain of this change, and that is why it is in a separate PR.

Obviously the code is longer, and it makes a lot of use of callbacks and futures, that (maybe) makes it less readable.

OTOH, the previous approach had all kinds of bad practices embedded in it, and it was probably hard to see how would one scale beyond a single request running in a loop in `main()`.
