### PR TITLE
ci: modernize CMake files

### DIFF
--- a/cloud-run-hello-world/CMakeLists.txt
+++ b/cloud-run-hello-world/CMakeLists.txt
@@ -15,14 +15,12 @@
 # ~~~
 
 # [START cloudrun_helloworld_makelist]
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT
     "https://github.com/GoogleCloudPlatform/cpp-samples/issues")
-project(cpp-samples-cloud-run-hello-world CXX C)
-
-# Configure the Compiler options, we will be using C++17 features.
+project(cpp-samples-cloud-run-hello-world CXX)
 
 find_package(functions_framework_cpp REQUIRED)
 find_package(Threads)

--- a/gcs-fast-transfers/CMakeLists.txt
+++ b/gcs-fast-transfers/CMakeLists.txt
@@ -14,16 +14,12 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT
     "https://github.com/GoogleCloudPlatform/cpp-samples/issues")
 project(GCS-Fast-Transfers CXX)
-
-# Configure the Compiler options, we will be using C++17 features.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(google_cloud_cpp_storage REQUIRED)
 find_package(Crc32c REQUIRED)
@@ -33,22 +29,20 @@ find_package(Threads)
 
 add_library(gcs_fast_transfers STATIC gcs_fast_transfers.cc
                                       gcs_fast_transfers.h)
+target_compile_features(gcs_fast_transfers PUBLIC cxx_std_17)
 target_link_libraries(gcs_fast_transfers PRIVATE Boost::headers Crc32c::crc32c)
 
 add_executable(download download.cc)
+target_compile_features(download PRIVATE cxx_std_17)
 target_link_libraries(
   download PRIVATE gcs_fast_transfers google-cloud-cpp::storage
                    Boost::program_options fmt::fmt Threads::Threads)
 
 add_executable(upload upload.cc)
+target_compile_features(download PRIVATE cxx_std_17)
 target_link_libraries(
   upload PRIVATE gcs_fast_transfers google-cloud-cpp::storage
                  Boost::program_options fmt::fmt Threads::Threads)
-
-find_package(CURL REQUIRED)
-find_package(Boost 1.66 REQUIRED COMPONENTS program_options)
-find_package(OpenSSL REQUIRED)
-find_package(ZLIB REQUIRED)
 
 include(GNUInstallDirs)
 install(TARGETS download upload RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/gcs-fast-transfers/vcpkg.json
+++ b/gcs-fast-transfers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-samples-gcs-fast-transfers",
-  "version-string": "0.1.0",
+  "version-string": "unversioned",
   "homepage": "https://github.com/GoogleCloudPlatform/cpp-samples/",
   "description": [
     "Shows how to parallelize downloads with GCS.",

--- a/getting-started/CMakeLists.txt
+++ b/getting-started/CMakeLists.txt
@@ -14,11 +14,8 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(cpp-samples-getting-started CXX)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(functions_framework_cpp REQUIRED)
 find_package(google_cloud_cpp_pubsub REQUIRED)

--- a/getting-started/update/CMakeLists.txt
+++ b/getting-started/update/CMakeLists.txt
@@ -14,10 +14,8 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(cpp-samples-getting-started-update CXX)
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(functions_framework_cpp REQUIRED)
 find_package(google_cloud_cpp_spanner REQUIRED)
@@ -25,7 +23,7 @@ find_package(google_cloud_cpp_spanner REQUIRED)
 add_library(
   functions_framework_cpp_function EXCLUDE_FROM_ALL # cmake-format: sortable
                                                     update_gcs_index.cc)
+target_compile_features(functions_framework_cpp_function PUBLIC cxx_std_17)
 target_link_libraries(
   functions_framework_cpp_function PUBLIC functions-framework-cpp::framework
                                           google-cloud-cpp::spanner)
-target_compile_features(functions_framework_cpp_function PUBLIC cxx_std_17)

--- a/iot/mqtt-ciotc/CMakeLists.txt
+++ b/iot/mqtt-ciotc/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT

--- a/iot/mqtt-ciotc/vcpkg.json
+++ b/iot/mqtt-ciotc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-samples-iot-mqtt-ciotc",
-  "version-string": "0.0.1-dev",
+  "version-string": "unversioned",
   "port-version": 1,
   "homepage": "https://github.com/GoogleCloudPlatform/cpp-samples/",
   "description": "Message Queue Telemetry Transport (MQTT) example for Google Cloud Core IoT.",

--- a/populate-bucket/CMakeLists.txt
+++ b/populate-bucket/CMakeLists.txt
@@ -14,16 +14,12 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT
     "https://github.com/GoogleCloudPlatform/cpp-samples/issues")
 project(populate-bucket CXX)
-
-# Configure the Compiler options, we will be using C++17 features.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(google_cloud_cpp_pubsub REQUIRED)
 find_package(google_cloud_cpp_storage REQUIRED)
@@ -31,6 +27,7 @@ find_package(Boost 1.66 REQUIRED COMPONENTS program_options)
 find_package(Threads)
 
 add_executable(populate_bucket populate_bucket.cc)
+target_compile_features(populate_bucket PRIVATE cxx_std_17)
 target_link_libraries(
   populate_bucket PRIVATE google-cloud-cpp::pubsub google-cloud-cpp::storage
                           Boost::program_options Threads::Threads)

--- a/populate-bucket/vcpkg.json
+++ b/populate-bucket/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-cpp-samples-populate-bucket",
-  "version-string": "0.0.1-dev",
+  "version-string": "unversioned",
   "port-version": 1,
   "homepage": "https://github.com/GoogleCloudPlatform/cpp-samples/",
   "description": "Running GKE Batch Jobs with C++",


### PR DESCRIPTION
Consistently require CMake >= 3.20, and prefer using
`target_compile_features()` to set the C++ standard.