### PR TITLE
chore(deps): update to the latest vcpkg release

### DIFF
--- a/ci/devtools.Dockerfile
+++ b/ci/devtools.Dockerfile
@@ -27,7 +27,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 WORKDIR /usr/local/vcpkg
 # Pin vcpkg to the latest released version. Renovatebot sends PRs when there is a new release.
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.07.25.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh \
     && /usr/local/vcpkg/vcpkg fetch cmake \

--- a/ci/devtools.Dockerfile
+++ b/ci/devtools.Dockerfile
@@ -27,7 +27,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 WORKDIR /usr/local/vcpkg
 # Pin vcpkg to the latest released version. Renovatebot sends PRs when there is a new release.
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh \
     && /usr/local/vcpkg/vcpkg fetch cmake \

--- a/ci/devtools.Dockerfile
+++ b/ci/devtools.Dockerfile
@@ -27,7 +27,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 WORKDIR /usr/local/vcpkg
 # Pin vcpkg to the latest released version. Renovatebot sends PRs when there is a new release.
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.27.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh \
     && /usr/local/vcpkg/vcpkg fetch cmake \

--- a/cloud-run-hello-world/Dockerfile
+++ b/cloud-run-hello-world/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update && \
 # Use `vcpkg`, a package manager for C++, to install 
 WORKDIR /usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=1
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.07.25.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/cloud-run-hello-world/Dockerfile
+++ b/cloud-run-hello-world/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update && \
 # Use `vcpkg`, a package manager for C++, to install 
 WORKDIR /usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=1
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.27.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/cloud-run-hello-world/Dockerfile
+++ b/cloud-run-hello-world/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update && \
 # Use `vcpkg`, a package manager for C++, to install 
 WORKDIR /usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=1
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -42,7 +42,7 @@ RUN apt update && \
 FROM devtools AS build
 
 WORKDIR /v/vcpkg
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.27.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -42,7 +42,7 @@ RUN apt update && \
 FROM devtools AS build
 
 WORKDIR /v/vcpkg
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.278.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -42,7 +42,7 @@ RUN apt update && \
 FROM devtools AS build
 
 WORKDIR /v/vcpkg
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.07.25.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.09.17.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/getting-started/index_gcs_prefix.cc
+++ b/getting-started/index_gcs_prefix.cc
@@ -105,7 +105,7 @@ gcf::HttpResponse IndexGcsPrefix(gcf::HttpRequest request) {  // NOLINT
     return gcs::StartOffset(attributes.value("start", ""));
   }();
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   auto publisher = GetPublisher();
 
   int mutation_count = 0;

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.278tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.27tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.27tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.27.tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.07.25.tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.17tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.17tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.09.278tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to


### PR DESCRIPTION
With this new release we get a newer version of `google-cloud-cpp`, which deprecates a number of functions. I updated the examples to match.