### PR TITLE
ci: switch builds to top-level CMake file

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,50 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tab_size = 4
+separate_ctrl_name_with_space = True
+enable_sort = True
+autosort = True
+
+additional_commands = {
+    "externalproject_add": {
+        "flags": [],
+        "kwargs": {
+            "BUILD_COMMAND": "+",
+            "BUILD_BYPRODUCTS": "+",
+            "CMAKE_ARGS": "+",
+            "COMMAND": "+",
+            "CONFIGURE_COMMAND": "+",
+            "DEPENDS": "+",
+            "DOWNLOAD_COMMAND": "+",
+            "EXCLUDE_FROM_ALL": 1,
+            "INSTALL_COMMAND": "+",
+            "INSTALL_DIR": 1,
+            "LIST_SEPARATOR": 1,
+            "TEST_COMMAND": "+",
+            "PATCH_COMMAND": "+",
+            "LOG_BUILD": 1,
+            "LOG_CONFIGURE": 1,
+            "LOG_DOWNLOAD": 1,
+            "LOG_INSTALL": 1,
+            "PREFIX": 1,
+            "URL": 1,
+            "URL_HASH": 1,
+            "BUILD_ALWAYS": 1,
+            "LOG_OUTPUT_ON_FAILURE": 1,
+            "SOURCE_DIR": 1,
+            "BINARY_DIR": 1,
+        },
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.20...3.23)
+project(cpp-samples CXX C)
+
+include(ExternalProject)
+
+set(samples
+    # cmake-format: sort
+    bigquery/write
+    cloud-run-hello-world
+    gcs-fast-transfers
+    getting-started
+    getting-started/update
+    iot/mqtt-ciotc
+    populate-bucket
+    speech/api)
+
+add_custom_target(verify-samples ALL)
+
+function (add_sample_directory dir)
+    string(REPLACE "/" "-" name "${dir}")
+
+    externalproject_add(
+        verify-sample-${name}
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${PROJECT_BINARY_DIR}/cmake-prefix-${name}"
+        SOURCE_DIR "${PROJECT_SOURCE_DIR}/${dir}"
+        BINARY_DIR "${PROJECT_BINARY_DIR}/${dir}"
+        CMAKE_ARGS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+        BUILD_COMMAND "${CMAKE_COMMAND}" "--build" "<BINARY_DIR>"
+        BUILD_ALWAYS ON
+        INSTALL_COMMAND ""
+        # Use LOG_* ON to keep builds quiet on success
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_OUTPUT_ON_FAILURE ON)
+    add_dependencies(verify-samples verify-sample-${name})
+endfunction ()
+
+foreach (sample IN LISTS samples)
+    add_sample_directory("${sample}")
+endforeach ()

--- a/bigquery/write/CMakeLists.txt
+++ b/bigquery/write/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(Threads)
 
 protobuf_generate_cpp(SCHEMA_SRCS SCHEMA_HDRS schema.proto)
 
-add_executable("single_threaded_write" single_threaded_write.cc ${SCHEMA_SRCS})
+add_executable("single_threaded_write" ${SCHEMA_SRCS} single_threaded_write.cc)
 target_include_directories(single_threaded_write SYSTEM
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries("single_threaded_write" PRIVATE google-cloud-cpp::bigquery

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -91,127 +91,17 @@ steps:
   - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
     waitFor: [ 'vcpkg-warmup' ]
     volumes:
-      - name: 'cloud-run-hello-world'
+      - name: 'top-level'
         path: '/b'
     args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/cloud-run-hello-world', '-B', '/b',
+        'cmake', '-G', 'Ninja', '-S', '/workspace', '-B', '/b',
+        '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
     ]
   - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
     volumes:
-      - name: 'cloud-run-hello-world'
+      - name: 'top-level'
         path: '/b'
     args: [ 'cmake', '--build', '/b', ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'gcs-fast-transfers'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/gcs-fast-transfers', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'gcs-fast-transfers'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'bigquery-write'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/bigquery/write', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'bigquery-write'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'getting-started'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/getting-started', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'getting-started'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b', '--target', 'functions_framework_cpp_function' ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'getting-started'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b', '--target', 'gke_index_gcs' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'getting-started-update'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/getting-started/update', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'getting-started-update'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b', '--target', 'functions_framework_cpp_function' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'iot-mqtt-ciotc'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/iot/mqtt-ciotc', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'iot-mqtt-ciotc'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'populate-bucket'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/populate-bucket', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'populate-bucket'
-        path: '/b'
-    args: [ 'cmake', '--build', '/b' ]
-
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    waitFor: [ 'vcpkg-warmup' ]
-    volumes:
-      - name: 'speech-api'
-        path: '/b'
-    args: [
-        'cmake', '-DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake',
-        '-S', '/workspace/speech/api', '-B', '/b',
-    ]
-  - name: 'gcr.io/${PROJECT_ID}/cpp-samples/ci/devtools:${BUILD_ID}'
-    volumes:
-      - name: 'speech-api'
-        path: '/b'
-    args: ['cmake', '--build', '/b']
 
   # Remove the images created by this build.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/gcs-fast-transfers/CMakeLists.txt
+++ b/gcs-fast-transfers/CMakeLists.txt
@@ -35,14 +35,14 @@ target_link_libraries(gcs_fast_transfers PRIVATE Boost::headers Crc32c::crc32c)
 add_executable(download download.cc)
 target_compile_features(download PRIVATE cxx_std_17)
 target_link_libraries(
-  download PRIVATE gcs_fast_transfers google-cloud-cpp::storage
-                   Boost::program_options fmt::fmt Threads::Threads)
+    download PRIVATE gcs_fast_transfers google-cloud-cpp::storage
+                     Boost::program_options fmt::fmt Threads::Threads)
 
 add_executable(upload upload.cc)
 target_compile_features(download PRIVATE cxx_std_17)
 target_link_libraries(
-  upload PRIVATE gcs_fast_transfers google-cloud-cpp::storage
-                 Boost::program_options fmt::fmt Threads::Threads)
+    upload PRIVATE gcs_fast_transfers google-cloud-cpp::storage
+                   Boost::program_options fmt::fmt Threads::Threads)
 
 include(GNUInstallDirs)
 install(TARGETS download upload RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/getting-started/CMakeLists.txt
+++ b/getting-started/CMakeLists.txt
@@ -22,30 +22,29 @@ find_package(google_cloud_cpp_pubsub REQUIRED)
 find_package(google_cloud_cpp_spanner REQUIRED)
 find_package(google_cloud_cpp_storage REQUIRED)
 
-add_library(gcs_indexing EXCLUDE_FROM_ALL # cmake-format: sortable
-                                          gcs_indexing.cc gcs_indexing.h)
+add_library(gcs_indexing # cmake-format: sort
+            gcs_indexing.cc gcs_indexing.h)
 target_link_libraries(gcs_indexing PUBLIC google-cloud-cpp::spanner
                                           google-cloud-cpp::storage)
 target_include_directories(gcs_indexing PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_features(gcs_indexing PUBLIC cxx_std_17)
 
-add_library(
-  functions_framework_cpp_function EXCLUDE_FROM_ALL # cmake-format: sortable
-                                                    index_gcs_prefix.cc)
+add_library(functions_framework_cpp_function # cmake-format: sort
+            index_gcs_prefix.cc)
 target_link_libraries(
-  functions_framework_cpp_function
-  PRIVATE gcs_indexing
-  PUBLIC functions-framework-cpp::framework google-cloud-cpp::pubsub
-         google-cloud-cpp::spanner google-cloud-cpp::storage)
+    functions_framework_cpp_function
+    PRIVATE gcs_indexing
+    PUBLIC functions-framework-cpp::framework google-cloud-cpp::pubsub
+           google-cloud-cpp::spanner google-cloud-cpp::storage)
 target_compile_features(functions_framework_cpp_function PUBLIC cxx_std_17)
 
-add_executable(gke_index_gcs EXCLUDE_FROM_ALL gke/index_gcs.cc)
+add_executable(gke_index_gcs gke/index_gcs.cc)
 target_link_libraries(
-  gke_index_gcs PRIVATE gcs_indexing google-cloud-cpp::pubsub
-                        google-cloud-cpp::spanner google-cloud-cpp::storage)
+    gke_index_gcs PRIVATE gcs_indexing google-cloud-cpp::pubsub
+                          google-cloud-cpp::spanner google-cloud-cpp::storage)
 
-add_library(update_gcs_index EXCLUDE_FROM_ALL # cmake-format: sortable
-                                              update/update_gcs_index.cc)
+add_library(update_gcs_index # cmake-format: sort
+            update/update_gcs_index.cc)
 target_link_libraries(update_gcs_index PUBLIC functions-framework-cpp::framework
                                               google-cloud-cpp::spanner)
 target_compile_features(update_gcs_index PUBLIC cxx_std_17)

--- a/getting-started/update/CMakeLists.txt
+++ b/getting-started/update/CMakeLists.txt
@@ -20,10 +20,9 @@ project(cpp-samples-getting-started-update CXX)
 find_package(functions_framework_cpp REQUIRED)
 find_package(google_cloud_cpp_spanner REQUIRED)
 
-add_library(
-  functions_framework_cpp_function EXCLUDE_FROM_ALL # cmake-format: sortable
-                                                    update_gcs_index.cc)
+add_library(functions_framework_cpp_function # cmake-format: sort
+            update_gcs_index.cc)
 target_compile_features(functions_framework_cpp_function PUBLIC cxx_std_17)
 target_link_libraries(
-  functions_framework_cpp_function PUBLIC functions-framework-cpp::framework
-                                          google-cloud-cpp::spanner)
+    functions_framework_cpp_function PUBLIC functions-framework-cpp::framework
+                                            google-cloud-cpp::spanner)

--- a/iot/mqtt-ciotc/CMakeLists.txt
+++ b/iot/mqtt-ciotc/CMakeLists.txt
@@ -28,17 +28,17 @@ find_package(eclipse-paho-mqtt-c REQUIRED)
 # libjwt is not available through vcpkg, we use FetchContent instead.
 include(FetchContent)
 FetchContent_Declare(
-  libjwt
-  URL https://github.com/benmcollins/libjwt/archive/b6849cbea22f43bbd2f115c3bab55ad903272c62.tar.gz
+    libjwt
+    URL https://github.com/benmcollins/libjwt/archive/b6849cbea22f43bbd2f115c3bab55ad903272c62.tar.gz
 )
 FetchContent_GetProperties(libjwt)
-if(NOT libjwt_POPULATED)
-  FetchContent_Populate(libjwt)
-  add_subdirectory(${libjwt_SOURCE_DIR} ${libjwt_BINARY_DIR})
-endif()
+if (NOT libjwt_POPULATED)
+    FetchContent_Populate(libjwt)
+    add_subdirectory(${libjwt_SOURCE_DIR} ${libjwt_BINARY_DIR})
+endif ()
 
 add_executable(mqtt_ciotc mqtt_ciotc.c)
 target_link_libraries(
-  mqtt_ciotc PRIVATE jwt jansson::jansson
-                     eclipse-paho-mqtt-c::paho-mqtt3cs-static)
+    mqtt_ciotc PRIVATE jwt jansson::jansson
+                       eclipse-paho-mqtt-c::paho-mqtt3cs-static)
 target_include_directories(mqtt_ciotc PRIVATE "${libjwt_SOURCE_DIR}/include")

--- a/populate-bucket/CMakeLists.txt
+++ b/populate-bucket/CMakeLists.txt
@@ -29,8 +29,8 @@ find_package(Threads)
 add_executable(populate_bucket populate_bucket.cc)
 target_compile_features(populate_bucket PRIVATE cxx_std_17)
 target_link_libraries(
-  populate_bucket PRIVATE google-cloud-cpp::pubsub google-cloud-cpp::storage
-                          Boost::program_options Threads::Threads)
+    populate_bucket PRIVATE google-cloud-cpp::pubsub google-cloud-cpp::storage
+                            Boost::program_options Threads::Threads)
 
 include(GNUInstallDirs)
 install(TARGETS populate_bucket RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/speech/api/CMakeLists.txt
+++ b/speech/api/CMakeLists.txt
@@ -28,30 +28,32 @@ find_package(Threads)
 add_library(parse_arguments STATIC parse_arguments.cc parse_arguments.h)
 target_compile_features(parse_arguments PUBLIC cxx_std_14)
 target_link_libraries(
-  parse_arguments PUBLIC Boost::program_options
-                         google-cloud-cpp::cloud_speech_protos)
-if(MSVC)
-  # The protobuf-generated files have warnings under the default MSVC settings.
-  # We are not interested in these warnings, because we cannot fix them.
-  target_compile_options(parse_arguments PUBLIC "/wd4244" "/wd4251")
-endif()
+    parse_arguments PUBLIC Boost::program_options
+                           google-cloud-cpp::cloud_speech_protos)
+if (MSVC)
+    # The protobuf-generated files have warnings under the default MSVC
+    # settings. We are not interested in these warnings, because we cannot fix
+    # them.
+    target_compile_options(parse_arguments PUBLIC "/wd4244" "/wd4251")
+endif ()
 
-foreach(target async_transcribe streaming_transcribe
-               streaming_transcribe_singlethread transcribe)
-  add_executable("${target}" "${target}.cc")
-  target_link_libraries(
-    "${target}" PRIVATE parse_arguments google-cloud-cpp::speech
-                        Boost::program_options Threads::Threads)
-endforeach()
+foreach (target async_transcribe streaming_transcribe
+                streaming_transcribe_singlethread transcribe)
+    add_executable("${target}" "${target}.cc")
+    target_link_libraries(
+        "${target}" PRIVATE parse_arguments google-cloud-cpp::speech
+                            Boost::program_options Threads::Threads)
+endforeach ()
 
-if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-   AND ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 11))
-  add_executable(streaming_transcribe_coroutines
-                 streaming_transcribe_coroutines.cc)
-  target_compile_features(streaming_transcribe_coroutines PUBLIC cxx_std_20)
-  target_compile_options(streaming_transcribe_coroutines PUBLIC "-fcoroutines")
-  target_link_libraries(
-    streaming_transcribe_coroutines
-    PRIVATE parse_arguments google-cloud-cpp::speech Boost::program_options
-            Threads::Threads)
-endif()
+if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+    AND ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 11))
+    add_executable(streaming_transcribe_coroutines
+                   streaming_transcribe_coroutines.cc)
+    target_compile_features(streaming_transcribe_coroutines PUBLIC cxx_std_20)
+    target_compile_options(streaming_transcribe_coroutines
+                           PUBLIC "-fcoroutines")
+    target_link_libraries(
+        streaming_transcribe_coroutines
+        PRIVATE parse_arguments google-cloud-cpp::speech Boost::program_options
+                Threads::Threads)
+endif ()


### PR DESCRIPTION
Maintaining the YAML file for Google Cloud Build was getting tedious. Using a top-level CMake file would be easier to maintain, all we would need to do is add new directories to the sample list.  The top-level CMake file is a super build. This is to validate the configure+build steps in each directory work. In contrast, using `add_subdirectory()` would build everthing, but would configure only once, using the top-level CMake file.