### PR TITLE
chore(deps): update vcpkg to v2023.01.09

### DIFF
--- a/bigquery/write/single_threaded_write.cc
+++ b/bigquery/write/single_threaded_write.cc
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   auto const project_id = std::string{argv[1]};
   auto client = bq::BigQueryWriteClient(bq::MakeBigQueryWriteConnection());
 
-  auto stream = client.AsyncAppendRows(google::cloud::ExperimentalTag{});
+  auto stream = client.AsyncAppendRows();
   auto handle_broken_stream = [&stream](char const* where) {
     auto status = stream->Finish().get();
     std::cerr << "Unexpected streaming RPC error in " << where << ": " << status

--- a/ci/devtools.Dockerfile
+++ b/ci/devtools.Dockerfile
@@ -27,7 +27,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 WORKDIR /usr/local/vcpkg
 # Pin vcpkg to the latest released version. Renovatebot sends PRs when there is a new release.
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.11.14.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2023.01.09.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh \
     && /usr/local/vcpkg/vcpkg fetch cmake \

--- a/cloud-run-hello-world/Dockerfile
+++ b/cloud-run-hello-world/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && \
 # Use `vcpkg`, a package manager for C++, to install 
 WORKDIR /usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=1
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.11.14.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2023.01.09.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -42,7 +42,7 @@ RUN apt update && \
 FROM devtools AS build
 
 WORKDIR /v/vcpkg
-RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2022.11.14.tar.gz" | \
+RUN curl -sSL "https://github.com/Microsoft/vcpkg/archive/2023.01.09.tar.gz" | \
     tar --strip-components=1 -zxf - \
     && ./bootstrap-vcpkg.sh -disableMetrics
 

--- a/populate-bucket/Dockerfile
+++ b/populate-bucket/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS devtools
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y curl gzip tar unzip
 WORKDIR /var/tmp/build/vcpkg
-RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2022.11.14.tar.gz | \
+RUN curl -s -L https://github.com/Microsoft/vcpkg/archive/2023.01.09.tar.gz | \
     tar -xzf - --strip-components=1
 
 # Install the typical development tools, zip + unzip are used by vcpkg to

--- a/speech/api/streaming_transcribe.cc
+++ b/speech/api/streaming_transcribe.cc
@@ -71,8 +71,7 @@ int main(int argc, char** argv) try {
   *streaming_config.mutable_config() = args.config;
 
   // Begin a stream.
-  auto stream =
-      client.AsyncStreamingRecognize(google::cloud::ExperimentalTag{});
+  auto stream = client.AsyncStreamingRecognize();
   // The stream can fail to start, and `.get()` returns an error in this case.
   if (!stream->Start().get()) throw stream->Finish().get();
   // Write the first request, containing the config only.

--- a/speech/api/streaming_transcribe_coroutines.cc
+++ b/speech/api/streaming_transcribe_coroutines.cc
@@ -85,8 +85,7 @@ g::future<g::Status> StreamingTranscribe(g::CompletionQueue cq,
   *streaming_config.mutable_config() = std::move(args.config);
 
   // Get ready to write audio content.  Create the stream, and start it.
-  auto stream =
-      client.AsyncStreamingRecognize(google::cloud::ExperimentalTag{});
+  auto stream = client.AsyncStreamingRecognize();
 
   // The stream can fail to start; `.get()` returns `false` in this case.
   if (!co_await stream->Start()) co_return co_await stream->Finish();

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -42,7 +42,7 @@ class Handler : public std::enable_shared_from_this<Handler> {
 
   g::future<g::Status> Start(speech::SpeechClient& client) {
     // Get ready to write audio content.  Create the stream, and start it.
-    stream_ = client.AsyncStreamingRecognize(google::cloud::ExperimentalTag{});
+    stream_ = client.AsyncStreamingRecognize();
     // The stream can fail to start; `.get()` returns `false` in this case.
     if (!stream_->Start().get()) return StartFailure();
     // Write the first request, containing the config only.


### PR DESCRIPTION
This version the changes to `google-cloud-cpp` that remove `ExperimentalTag{}` from bi-directional streaming RPCs.