### PR TITLE
fix(speech/api): prevent segfault when arguments aren't parsed correctly

### DIFF
--- a/speech/api/streaming_transcribe_coroutines.cc
+++ b/speech/api/streaming_transcribe_coroutines.cc
@@ -114,15 +114,15 @@ int main(int argc, char* argv[]) try {
   // operations, and dedicate a thread to it.
   g::CompletionQueue cq;
   auto runner = std::thread{[](auto cq) { cq.Run(); }, cq};
-  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) { cq.Shutdown(); runner.join(); });
+  // Shutdown the completion queue and join the thread.
+  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) {
+    cq.Shutdown();
+    runner.join();
+  });
 
   // Run a streaming transcription. Note that `.get()` blocks until it
   // completes.
   auto status = StreamingTranscribe(cq, ParseArguments(argc, argv)).get();
-
-  // Shutdown the completion queue.
-  cq.Shutdown();
-  runner.join();
 
   if (!status.ok()) {
     std::cerr << "Error in transcribe stream: " << status << "\n";

--- a/speech/api/streaming_transcribe_coroutines.cc
+++ b/speech/api/streaming_transcribe_coroutines.cc
@@ -114,6 +114,7 @@ int main(int argc, char* argv[]) try {
   // operations, and dedicate a thread to it.
   g::CompletionQueue cq;
   auto runner = std::thread{[](auto cq) { cq.Run(); }, cq};
+  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) { cq.Shutdown(); runner.join(); });
 
   // Run a streaming transcription. Note that `.get()` blocks until it
   // completes.

--- a/speech/api/streaming_transcribe_coroutines.cc
+++ b/speech/api/streaming_transcribe_coroutines.cc
@@ -30,7 +30,7 @@ using RecognizeStream = ::google::cloud::AsyncStreamingReadWriteRpc<
     speech::v1::StreamingRecognizeResponse>;
 
 auto constexpr kUsage = R"""(Usage:
-  streaming_transcribe_singlethread [--bitrate N] audio.(raw|ulaw|flac|amr|awb)
+  streaming_transcribe_coroutines [--bitrate N] audio.(raw|ulaw|flac|amr|awb)
 )""";
 
 // Print the responses as they are received.

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -153,7 +153,7 @@ class Handler : public std::enable_shared_from_this<Handler> {
 
 int main(int argc, char** argv) try {
   // Parse arguments before creating the thread. If this throws after
-  // the thread is created, the catch wil never get run and the program 
+  // the thread is created, the catch will never get run and the program
   // will call `std::abort()`.
   auto arguments = ParseArguments(argc, argv);
 

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -152,6 +152,11 @@ class Handler : public std::enable_shared_from_this<Handler> {
 };
 
 int main(int argc, char** argv) try {
+  // Parse arguments before creating the thread. If this throws after
+  // the thread is created, the catch wil never get run and the program 
+  // will call `std::abort()`.
+  auto arguments = ParseArguments(argc, argv);
+
   // Create a CompletionQueue to demux the I/O and other asynchronous
   // operations, and dedicate a thread to it.
   g::CompletionQueue cq;
@@ -162,7 +167,7 @@ int main(int argc, char** argv) try {
       g::Options{}.set<g::GrpcCompletionQueueOption>(cq)));
 
   // Create a handler for the stream and run it until closed.
-  auto handler = Handler::Create(cq, ParseArguments(argc, argv));
+  auto handler = Handler::Create(cq, arguments);
   auto status = handler->Start(client).get();
 
   // Shutdown the completion queue

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -156,8 +156,11 @@ int main(int argc, char** argv) try {
   // operations, and dedicate a thread to it.
   g::CompletionQueue cq;
   auto runner = std::thread{[](auto cq) { cq.Run(); }, cq};
-  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) { cq.Shutdown(); runner.join(); });
-
+  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) {
+    cq.Shutdown();
+    runner.join();
+  });
+  
   // Create a Speech client with the default configuration.
   auto client = speech::SpeechClient(speech::MakeSpeechConnection(
       g::Options{}.set<g::GrpcCompletionQueueOption>(cq)));

--- a/speech/api/streaming_transcribe_singlethread.cc
+++ b/speech/api/streaming_transcribe_singlethread.cc
@@ -152,22 +152,18 @@ class Handler : public std::enable_shared_from_this<Handler> {
 };
 
 int main(int argc, char** argv) try {
-  // Parse arguments before creating the thread. If this throws after
-  // the thread is created, the catch will never get run and the program
-  // will call `std::abort()`.
-  auto arguments = ParseArguments(argc, argv);
-
   // Create a CompletionQueue to demux the I/O and other asynchronous
   // operations, and dedicate a thread to it.
   g::CompletionQueue cq;
   auto runner = std::thread{[](auto cq) { cq.Run(); }, cq};
+  std::shared_ptr<void> auto_shutdown(nullptr, [&](void*) { cq.Shutdown(); runner.join(); });
 
   // Create a Speech client with the default configuration.
   auto client = speech::SpeechClient(speech::MakeSpeechConnection(
       g::Options{}.set<g::GrpcCompletionQueueOption>(cq)));
 
   // Create a handler for the stream and run it until closed.
-  auto handler = Handler::Create(cq, arguments);
+  auto handler = Handler::Create(cq,  ParseArguments(argc, argv));
   auto status = handler->Start(client).get();
 
   // Shutdown the completion queue


### PR DESCRIPTION
Prevent https://github.com/GoogleCloudPlatform/cpp-samples/issues/252 from occurring

To verify, pass in command with an extra '-' so the arguments don't correctly parse:
```
pushd speech/api   
cmake -S. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
cmake --build .build       
GOOGLE_CLOUD_CPP_USER_PROJECT=alevenb-test .build/streaming_transcribe_singlethread ---bitrate 16000 resources/audio.raw
❯ GOOGLE_CLOUD_CPP_USER_PROJECT=alevenb-test .build/streaming_transcribe_singlethread ---bitrate 16000 resources/audio.raw
Standard C++ exception thrown: unrecognised option '---bitrate'
Usage:
  streaming_transcribe_singlethread [--bitrate N] audio.(raw|ulaw|flac|amr|awb)
```

No more segfaulting 🥳 