### PR TITLE
ci: fix schedule so it can parse

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["com_github_nelhage_rules_boost"],
-      "schedule": ["every month on the first day of the month"]
+      "schedule": ["before 4am on the first day of the month"]
     }
   ]
 }


### PR DESCRIPTION
I took this from https://docs.renovatebot.com/presets-schedule/#scheduleautomergemonthly

Fixes #275 