### PR TITLE
cleanup: pubsub-otel

### DIFF
--- a/pubsub-open-telemetry/README.md
+++ b/pubsub-open-telemetry/README.md
@@ -116,7 +116,7 @@ cmake --build .build --target quickstart
 #### Run the quickstart
 
 ```shell
-.build/quickstart [project-name] [topic-id]
+.build/quickstart ${GOOGLE_CLOUD_PROJECT} ${GOOGLE_CLOUD_TOPIC}
 ```
 
 ## Build and run using Bazel
@@ -139,13 +139,14 @@ bazel build //:quickstart
 #### Run the quickstart
 
 ```shell
-bazel run //:quickstart [project-name] [topic-id]
+bazel run //:quickstart -- ${GOOGLE_CLOUD_PROJECT} ${GOOGLE_CLOUD_TOPIC}
 ```
 
 #### Run with a local version of google-cloud-cpp
 
 ```shell
-bazel run //:quickstart --override_repository=google_cloud_cpp=$HOME/your-path-to-the-repo/google-cloud-cpp -- [project-name] [topic-id]
+bazel run --override_repository=google_cloud_cpp=$HOME/your-path-to-the-repo/google-cloud-cpp \
+    //:quickstart -- ${GOOGLE_CLOUD_PROJECT} ${GOOGLE_CLOUD_TOPIC}
 ```
 
 ## Cleanup

--- a/pubsub-open-telemetry/quickstart.cc
+++ b/pubsub-open-telemetry/quickstart.cc
@@ -21,11 +21,6 @@
 #include <utility>
 #include <vector>
 
-// Create a few namespace aliases to make the code easier to read.
-namespace gc = ::google::cloud;
-namespace pubsub = gc::pubsub;
-namespace otel = gc::otel;
-
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " <project-id> <topic-id>\n";
@@ -33,12 +28,17 @@ int main(int argc, char* argv[]) try {
   }
   std::string const project_id = argv[1];
   std::string const topic_id = argv[2];
-  auto project = gc::Project(project_id);
 
   //! [START pubsub_publish_otel_tracing]
+  // Create a few namespace aliases to make the code easier to read.
+  namespace gc = ::google::cloud;
+  namespace otel = gc::otel;
+  namespace pubsub = gc::pubsub;
+
   // This example uses a simple wrapper to export (upload) OTel tracing data
   // to Google Cloud Trace. More complex applications may use different
   // authentication, or configure their own OTel exporter.
+  auto project = gc::Project(project_id);
   auto configuration = otel::ConfigureBasicTracing(project);
 
   auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(


### PR DESCRIPTION
Move non-obvious types/namespaces into the region of the application used in our docs.

We define `GOOGLE_CLOUD_PROJECT=...` and `GOOGLE_CLOUD_TOPIC=...`, so use them as arguments when running the quickstart.