### PR TITLE
chore: no renovate-bot python updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
     "config:base",
     "schedule:weekdays"
   ],
+  "python": {
+    "enabled": false
+  },
   "regexManagers": [
     {
       "fileMatch": [


### PR DESCRIPTION
One of our samples has a python component. (It is temporary. We only use python because there is currently a gap in the C++ API).

Suppress `renovate-bot` updates of the requirements for that program. The PRs are more distracting than valuable.

We do the same thing in `google-cloud-cpp`:
https://github.com/googleapis/google-cloud-cpp/blob/68a939076eb6b824e3f6c3838c8f85cdced2b584/.github/renovate.json#L7-L9