### PR TITLE
Add ptime cmdline arg

### DIFF
--- a/speech/api/parse_arguments.cc
+++ b/speech/api/parse_arguments.cc
@@ -31,8 +31,8 @@ ParseResult ParseArguments(int argc, char* argv[]) {
       ("bitrate", po::value<int>()->default_value(16000),
        "the sample rate in Hz")
       //
-      ("ptime", po::value<int>()->default_value(20),
-       "packetization time in milliseconds")
+      ("ptime", po::value<int>()->default_value(0),
+       "(optional) packetization time in milliseconds")
       //
       ("language-code", po::value<std::string>()->default_value("en"),
        "the language code for the audio")
@@ -71,8 +71,9 @@ ParseResult ParseArguments(int argc, char* argv[]) {
   result.path = path;
   result.config.set_language_code(language_code);
   result.config.set_sample_rate_hertz(bitrate);
-  result.bitrate = bitrate;
-  result.ptime = ptime;
+  result.bitrate = 0;
+  result.ptime = 0;
+  result.sample_size = 0;
 
   // Use the audio file extension to configure the encoding.
   auto const ext = [&] {
@@ -86,8 +87,14 @@ ParseResult ParseArguments(int argc, char* argv[]) {
 
   if (ext.empty() || ext == ".raw") {
     result.config.set_encoding(RecognitionConfig::LINEAR16);
+    result.bitrate = bitrate;
+    result.ptime = ptime;
+    result.sample_size = 2;
   } else if (ext == ".ulaw") {
     result.config.set_encoding(RecognitionConfig::MULAW);
+    result.bitrate = 8000;
+    result.ptime = 20;
+    result.sample_size = 1;
   } else if (ext == ".flac") {
     result.config.set_encoding(RecognitionConfig::FLAC);
   } else if (ext == ".amr") {

--- a/speech/api/parse_arguments.cc
+++ b/speech/api/parse_arguments.cc
@@ -31,6 +31,9 @@ ParseResult ParseArguments(int argc, char* argv[]) {
       ("bitrate", po::value<int>()->default_value(16000),
        "the sample rate in Hz")
       //
+      ("ptime", po::value<int>()->default_value(20),
+       "packetization time in milliseconds")
+      //
       ("language-code", po::value<std::string>()->default_value("en"),
        "the language code for the audio")
       //
@@ -47,6 +50,7 @@ ParseResult ParseArguments(int argc, char* argv[]) {
 
   auto const path = vm["path"].as<std::string>();
   auto const bitrate = vm["bitrate"].as<int>();
+  auto const ptime = vm["ptime"].as<int>();
   auto const language_code = vm["language-code"].as<std::string>();
   // Validate the command-line options.
   if (path.empty()) {
@@ -57,11 +61,18 @@ ParseResult ParseArguments(int argc, char* argv[]) {
         "--bitrate option must be a positive number, value=" +
         std::to_string(bitrate));
   }
+  if (ptime < 0) {
+    throw std::runtime_error(
+        "--ptime option must be a positive number, value=" +
+        std::to_string(ptime));
+  }
 
   ParseResult result;
   result.path = path;
   result.config.set_language_code(language_code);
   result.config.set_sample_rate_hertz(bitrate);
+  result.bitrate = bitrate;
+  result.ptime = ptime;
 
   // Use the audio file extension to configure the encoding.
   auto const ext = [&] {

--- a/speech/api/parse_arguments.h
+++ b/speech/api/parse_arguments.h
@@ -25,6 +25,7 @@ struct ParseResult {
   std::string path;
   int bitrate;
   int ptime;
+  int sample_size;
 };
 
 ParseResult ParseArguments(int argc, char* argv[]);

--- a/speech/api/parse_arguments.h
+++ b/speech/api/parse_arguments.h
@@ -23,6 +23,8 @@
 struct ParseResult {
   google::cloud::speech::v1::RecognitionConfig config;
   std::string path;
+  int bitrate;
+  int ptime;
 };
 
 ParseResult ParseArguments(int argc, char* argv[]);

--- a/speech/api/streaming_transcribe.cc
+++ b/speech/api/streaming_transcribe.cc
@@ -27,17 +27,24 @@ using RecognizeStream = ::google::cloud::AsyncStreamingReadWriteRpc<
     speech::v1::StreamingRecognizeResponse>;
 
 auto constexpr kUsage = R"""(Usage:
-  streaming_transcribe [--bitrate N] audio.(raw|ulaw|flac|amr|awb)
+  streaming_transcribe [--bitrate N] [--ptime N] audio.(raw|ulaw|flac|amr|awb)
 )""";
 
 // Write the audio packet every ptime ms, simulating audio content arriving
 // from a microphone in ptime ms intervals
 void MicrophoneThreadMain(RecognizeStream& stream,
-                          std::string const& file_path, const int bitrate, const int ptime) {
+                          std::string const& file_path, const int bitrate, const int ptime, const int sample_size) {
   speech::v1::StreamingRecognizeRequest request;
   std::ifstream file_stream(file_path, std::ios::binary);
-  auto constexpr kChunkSize = 64 * 1024;
-  std::vector<char> chunk(kChunkSize);
+  // By default, read 64k bytes every 1 second
+  auto bytes_n = 64 * 1024;
+  auto wait_ms = 1000;
+  // If ptime is configured read packet every ptime ms (may only be set for "raw" and "ulaw")
+  if (ptime) {
+      wait_ms = ptime;
+      bytes_n = (bitrate / 1000) * sample_size * ptime;
+  }
+  std::vector<char> chunk(bytes_n);
   while (true) {
     // Read another chunk from the file.
     file_stream.read(chunk.data(), chunk.size());
@@ -45,7 +52,7 @@ void MicrophoneThreadMain(RecognizeStream& stream,
     // And write the chunk to the stream.
     if (bytes_read > 0) {
       request.set_audio_content(chunk.data(), bytes_read);
-      std::cout << "Sending " << bytes_read / 1024 << "k bytes." << std::endl;
+      std::cout << "Sending " << bytes_read << " bytes." << std::endl;
       if (!stream.Write(request, grpc::WriteOptions()).get()) break;
     }
     if (!file_stream) {
@@ -54,7 +61,7 @@ void MicrophoneThreadMain(RecognizeStream& stream,
       break;
     }
     // Wait a second before writing the next chunk.
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds (wait_ms));
   }
 }
 
@@ -67,6 +74,7 @@ int main(int argc, char** argv) try {
   auto const file_path = args.path;
   auto const bitrate = args.bitrate;
   auto const ptime = args.ptime;
+  auto const sample_size = args.sample_size;
 
   speech::v1::StreamingRecognizeRequest request;
   auto& streaming_config = *request.mutable_streaming_config();
@@ -84,7 +92,7 @@ int main(int argc, char** argv) try {
 
   // Simulate a microphone thread using the file as input.
   auto microphone =
-      std::thread(MicrophoneThreadMain, std::ref(*stream), file_path, bitrate, ptime);
+      std::thread(MicrophoneThreadMain, std::ref(*stream), file_path, bitrate, ptime, sample_size);
   // Read responses.
   auto read = [&stream] { return stream->Read().get(); };
   for (auto response = read(); response.has_value(); response = read()) {


### PR DESCRIPTION
By now, example code sends audio always in 64k chunks at a time.
However, in a real time audio processing scenarios audio is read at time intervals dictated by packetization time setting (_ptime_). As a user I need to test if the method shown (implemented) by example will work in my case (bitrate, ptime).

To provide more context, I work on text / speech processing in VoIP and in my processing audio is read in 20 ms packets from the audio call. The example on GoogleCloudPlatform sends audio in 1 second intervals though. I need to know if speech to text will work when I send packets as they come in my setup or if I need to implement buffering to send in 1 second chunks as example does.

This PR is adding a support for _ptime_ and bitrate command line args.
If set on _raw_ or _ulaw_ then packets are sent reflecting these settings. 
```
% .build/streaming_transcribe --help       

Standard C++ exception thrown: the option '--path' is required but missing
Usage:
  streaming_transcribe [--bitrate N] [--ptime N] audio.(raw|ulaw|flac|amr|awb)
```

Example 1. Using _ptime_ 20 ms:

```
% .build/streaming_transcribe --bitrate 16000 --ptime 20 resources/audio2.raw

Sending 640 bytes.
Sending 640 bytes.
Sending 640 bytes.
(...)
Sending 640 bytes.
Sending 640 bytes.
Sending 640 bytes.
Sending 640 bytes.
Sending 640 bytes.
Sending 640 bytes.
Result stability: 0
0.986006        the rain in Spain stays mainly on the plain
```


Example 2. Using _ptime_ 200 ms:

```
.build/streaming_transcribe --bitrate 16000 --ptime 200 resources/audio2.raw

Sending 6400 bytes.
Sending 6400 bytes.
Sending 6400 bytes.
(...)
Sending 6400 bytes.
Sending 6400 bytes.
Sending 6400 bytes.

Result stability: 0
0.986006        the rain in Spain stays mainly on the plain
```



