### PR TITLE
ci: request VM with updated cpu and more memory per core

### DIFF
--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'N2_STANDARD_32'
   diskSizeGb: '512'
   env:
     - 'VCPKG_BINARY_SOURCES=x-gcs,${_VCPKG_BUCKET_PREFIX},readwrite'


### PR DESCRIPTION
We recently had a build timeout, boost the VM specs to see if we can build faster.